### PR TITLE
fix(Symbolicate): Ensures symbolicate feature is working properly

### DIFF
--- a/ReactWindows/ReactNative.Tests/Chakra/Executor/ChakraJavaScriptExecutorTests.cs
+++ b/ReactWindows/ReactNative.Tests/Chakra/Executor/ChakraJavaScriptExecutorTests.cs
@@ -26,8 +26,12 @@ namespace ReactNative.Tests.Chakra.Executor
                     ex => Assert.AreEqual("arguments", ex.ParamName));
 
                 AssertEx.Throws<ArgumentNullException>(
-                    () => executor.RunScript(null),
+                    () => executor.RunScript(null, "foo"),
                     ex => Assert.AreEqual("script", ex.ParamName));
+
+                AssertEx.Throws<ArgumentNullException>(
+                    () => executor.RunScript("", null),
+                    ex => Assert.AreEqual("sourceUrl", ex.ParamName));
 
                 AssertEx.Throws<ArgumentNullException>(
                     () => executor.SetGlobalVariable(null, new JArray()),

--- a/ReactWindows/ReactNative.Tests/Internal/JavaScriptHelpers.cs
+++ b/ReactWindows/ReactNative.Tests/Internal/JavaScriptHelpers.cs
@@ -2,6 +2,7 @@
 using ReactNative.Bridge.Queue;
 using ReactNative.Chakra.Executor;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Windows.Storage;
@@ -44,19 +45,19 @@ namespace ReactNative.Tests
         {
             var scriptUris = new[]
             {
-                new Uri(@"ms-appx:///Resources/test.js"),
+                @"ms-appx:///Resources/test.js",
             };
 
-            var scripts = new string[scriptUris.Length];
+            var scripts = new KeyValuePair<string, string>[scriptUris.Length];
 
             for (var i = 0; i < scriptUris.Length; ++i)
             {
                 var uri = scriptUris[i];
-                var storageFile = await StorageFile.GetFileFromApplicationUriAsync(uri);
+                var storageFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri(uri));
                 using (var stream = await storageFile.OpenStreamForReadAsync())
                 using (var reader = new StreamReader(stream))
                 {
-                    scripts[i] = reader.ReadToEnd();
+                    scripts[i] = new KeyValuePair<string, string>(uri, reader.ReadToEnd());
                 }
             }
 
@@ -64,7 +65,7 @@ namespace ReactNative.Tests
             {
                 foreach (var script in scripts)
                 {
-                    executor.RunScript(script);
+                    executor.RunScript(script.Value, script.Key);
                 }
 
                 return true;

--- a/ReactWindows/ReactNative.Tests/Internal/MockJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative.Tests/Internal/MockJavaScriptExecutor.cs
@@ -7,19 +7,19 @@ namespace ReactNative.Tests
     class MockJavaScriptExecutor : IJavaScriptExecutor
     {
         private readonly Func<string, string, JArray, JToken> _onCall;
-        private readonly Action<string> _runScript;
+        private readonly Action<string, string> _runScript;
         private readonly Action<string, JToken> _onSetGlobalVariable;
         private readonly Action _onDispose;
 
         public MockJavaScriptExecutor(
             Func<string, string, JArray, JToken> onCall)
-            : this(onCall, _ => { }, (_, __) => { }, () => { })
+            : this(onCall, (_, __) => { }, (_, __) => { }, () => { })
         {
         }
 
         public MockJavaScriptExecutor(
             Func<string, string, JArray, JToken> onCall,
-            Action<string> runScript,
+            Action<string, string> runScript,
             Action<string, JToken> onSetGlobalVariable,
             Action onDispose)
         {
@@ -36,9 +36,9 @@ namespace ReactNative.Tests
             return _onCall(moduleName, methodName, arguments);
         }
 
-        public void RunScript(string script)
+        public void RunScript(string script, string sourceUrl)
         {
-            _runScript(script);
+            _runScript(script, sourceUrl);
         }
 
         public void SetGlobalVariable(string propertyName, JToken value)

--- a/ReactWindows/ReactNative/Bridge/IJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/Bridge/IJavaScriptExecutor.cs
@@ -28,6 +28,7 @@ namespace ReactNative.Bridge
         /// Runs the given script.
         /// </summary>
         /// <param name="script">The script.</param>
-        void RunScript(string script);
+        /// <param name="sourceUrl">The source URL.</param>
+        void RunScript(string script, string sourceUrl);
     }
 }

--- a/ReactWindows/ReactNative/Bridge/IReactBridge.cs
+++ b/ReactWindows/ReactNative/Bridge/IReactBridge.cs
@@ -35,6 +35,7 @@ namespace ReactNative.Bridge
         /// Evaluates JavaScript.
         /// </summary>
         /// <param name="script">The script.</param>
-        void RunScript(string script);
+        /// <param name="sourceUrl">The source URL.</param>
+        void RunScript(string script, string sourceUrl);
     }
 }

--- a/ReactWindows/ReactNative/Bridge/JavaScriptBundleLoader.cs
+++ b/ReactWindows/ReactNative/Bridge/JavaScriptBundleLoader.cs
@@ -107,7 +107,7 @@ namespace ReactNative.Bridge
                     throw new InvalidOperationException("Bundle loader has not yet been initialized.");
                 }
 
-                bridge.RunScript(_script);
+                bridge.RunScript(_script, SourceUrl);
                 
                 _script = null;
             }
@@ -147,7 +147,7 @@ namespace ReactNative.Bridge
 
             public override void LoadScript(IReactBridge executor)
             {
-                executor.RunScript(_script);
+                executor.RunScript(_script, SourceUrl);
             }
         }
 
@@ -173,7 +173,7 @@ namespace ReactNative.Bridge
 
             public override void LoadScript(IReactBridge executor)
             {
-                executor.RunScript(_proxySourceUrl);
+                executor.RunScript(_proxySourceUrl, SourceUrl);
             }
         }
     }

--- a/ReactWindows/ReactNative/Bridge/ReactBridge.cs
+++ b/ReactWindows/ReactNative/Bridge/ReactBridge.cs
@@ -98,12 +98,13 @@ namespace ReactNative.Bridge
         /// Evaluates JavaScript.
         /// </summary>
         /// <param name="script">The script.</param>
-        public void RunScript(string script)
+        /// <param name="sourceUrl">The source URL.</param>
+        public void RunScript(string script, string sourceUrl)
         {
             if (script == null)
                 throw new ArgumentNullException(nameof(script));
 
-            _jsExecutor.RunScript(script);
+            _jsExecutor.RunScript(script, sourceUrl);
             var response = _jsExecutor.Call("__fbBatchedBridge", "flushedQueue", s_empty);
 
             ProcessResponse(response);

--- a/ReactWindows/ReactNative/Bridge/ReactBridge.cs
+++ b/ReactWindows/ReactNative/Bridge/ReactBridge.cs
@@ -103,6 +103,8 @@ namespace ReactNative.Bridge
         {
             if (script == null)
                 throw new ArgumentNullException(nameof(script));
+            if (sourceUrl == null)
+                throw new ArgumentNullException(nameof(sourceUrl));
 
             _jsExecutor.RunScript(script, sourceUrl);
             var response = _jsExecutor.Call("__fbBatchedBridge", "flushedQueue", s_empty);

--- a/ReactWindows/ReactNative/DevSupport/WebSocketJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/DevSupport/WebSocketJavaScriptExecutor.cs
@@ -101,7 +101,7 @@ namespace ReactNative.DevSupport
             }
         }
 
-        public void RunScript(string script)
+        public void RunScript(string script, string sourceUrl)
         {
             var requestId = Interlocked.Increment(ref _requestId);
             var callback = new TaskCompletionSource<JToken>();


### PR DESCRIPTION
In order for the server-side symbolicate feature to work, Chakra needs to report the correct source filename.  Threading through the SourceUrl to the RunScript function to ensure this is correct for exceptions.

Fixes #433