### PR TITLE
fix(CLI) - fix csproj link - Closes Issue #470

### DIFF
--- a/local-cli/generator-windows/templates/proj/MyApp.csproj
+++ b/local-cli/generator-windows/templates/proj/MyApp.csproj
@@ -202,7 +202,7 @@
     </ApplicationDefinition>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\node_modules\react-native-windows\ReactNative\ReactNative.csproj">
+    <ProjectReference Include="..\..\..\node_modules\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj">
       <Project>{c7673ad5-e3aa-468c-a5fd-fa38154e205c}</Project>
       <Name>ReactNative</Name>
     </ProjectReference>
@@ -216,7 +216,7 @@
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>


### PR DESCRIPTION
Closes #470 with fix to `csproj` file location for ReactWindows