### PR TITLE
fix(TextInput): Fixes race between counter increment and JavaScript props changes

### DIFF
--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextBox.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextBox.cs
@@ -8,12 +8,10 @@ namespace ReactNative.Views.TextInput
     class ReactTextBox : TextBox, ILayoutManager
     {
         private int _eventCount;
-        private double _lastWidth;
-        private double _lastHeight;
 
         public ReactTextBox()
         {
-            LayoutUpdated += OnLayoutUpdated;
+            SizeChanged += OnSizeChanged;
         }
 
         public int CurrentEventCount
@@ -62,26 +60,18 @@ namespace ReactNative.Views.TextInput
             }
         }
 
-        private void OnLayoutUpdated(object sender, object e)
+        private void OnSizeChanged(object sender, SizeChangedEventArgs e)
         {
-            var width = ActualWidth;
-            var height = ActualHeight;
-            if (width != _lastWidth || height != _lastHeight)
-            {
-                _lastWidth = width;
-                _lastHeight = height;
-
-                this.GetReactContext()
-                    .GetNativeModule<UIManagerModule>()
-                    .EventDispatcher
-                    .DispatchEvent(
-                        new ReactTextChangedEvent(
-                            this.GetTag(),
-                            Text,
-                            width,
-                            height,
-                            IncrementEventCount()));
-            }
+            this.GetReactContext()
+                .GetNativeModule<UIManagerModule>()
+                .EventDispatcher
+                .DispatchEvent(
+                    new ReactTextChangedEvent(
+                        this.GetTag(),
+                        Text,
+                        e.NewSize.Width,
+                        e.NewSize.Height,
+                        IncrementEventCount()));
         }
     }
 }

--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
@@ -405,33 +405,38 @@ namespace ReactNative.Views.TextInput
             }
             else if ((textUpdate = extraData as Tuple<int, string>) != null)
             {
-                if (textUpdate.Item1 < view.CurrentEventCount)
+                var javaScriptCount = textUpdate.Item1;
+                if (javaScriptCount < view.CurrentEventCount)
                 {
                     return;
                 }
 
-                var text = textUpdate.Item2;
-
+                view.TextChanging -= OnTextChanging;
                 view.TextChanged -= OnTextChanged;
+
                 if (_onSelectionChange)
                 {
                     view.SelectionChanged -= OnSelectionChanged;
                 }
 
+                var text = textUpdate.Item2;
                 var selectionStart = view.SelectionStart;
                 var selectionLength = view.SelectionLength;
                 var textLength = text?.Length ?? 0;
                 var maxLength = textLength - selectionLength;
 
+                var currText = view.Text;
                 view.Text = text ?? "";
                 view.SelectionStart = Math.Min(selectionStart, textLength);
                 view.SelectionLength = Math.Min(selectionLength, maxLength < 0 ? 0 : maxLength);
 
-                view.TextChanged += OnTextChanged;
                 if (_onSelectionChange)
                 {
                     view.SelectionChanged += OnSelectionChanged;
                 }
+
+                view.TextChanged += OnTextChanged;
+                view.TextChanging += OnTextChanging;
             }
         }
 
@@ -448,6 +453,7 @@ namespace ReactNative.Views.TextInput
             view.LostFocus -= OnLostFocus;
             view.GotFocus -= OnGotFocus;
             view.TextChanged -= OnTextChanged;
+            view.TextChanging -= OnTextChanging;
         }
 
         /// <summary>
@@ -470,10 +476,17 @@ namespace ReactNative.Views.TextInput
         /// <param name="view">The <see cref="ReactTextBox"/> view instance.</param>
         protected override void AddEventEmitters(ThemedReactContext reactContext, ReactTextBox view)
         {
+            view.TextChanging += OnTextChanging;
             view.TextChanged += OnTextChanged;
             view.GotFocus += OnGotFocus;
             view.LostFocus += OnLostFocus;
             view.KeyDown += OnKeyDown;
+        }
+
+        private void OnTextChanging(TextBox sender, TextBoxTextChangingEventArgs args)
+        {
+            var textBox = (ReactTextBox)sender;
+            textBox.IncrementEventCount();
         }
 
         private void OnTextChanged(object sender, TextChangedEventArgs e)
@@ -488,7 +501,7 @@ namespace ReactNative.Views.TextInput
                         textBox.Text,
                         textBox.ActualWidth,
                         textBox.ActualHeight,
-                        textBox.IncrementEventCount()));
+                        textBox.CurrentEventCount));
         }
 
         private void OnGotFocus(object sender, RoutedEventArgs e)

--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
@@ -425,7 +425,6 @@ namespace ReactNative.Views.TextInput
                 var textLength = text?.Length ?? 0;
                 var maxLength = textLength - selectionLength;
 
-                var currText = view.Text;
                 view.Text = text ?? "";
                 view.SelectionStart = Math.Min(selectionStart, textLength);
                 view.SelectionLength = Math.Min(selectionLength, maxLength < 0 ? 0 : maxLength);


### PR DESCRIPTION
Previously, the native event count was not updated until the TextChanged event fired, which could be interrupted by a previous props update. When this occurred, we could potentially replace the text with the state of a previous event.

Now, the native event count is pre-incremented in th TextChanging event. This seems to resolve the race condition.

Fixes #490