### PR TITLE
feat(runWindows): Adds option to start application with remote debugging

### DIFF
--- a/ReactWindows/Playground/App.xaml.cs
+++ b/ReactWindows/Playground/App.xaml.cs
@@ -57,7 +57,7 @@ namespace Playground
             // just ensure that the window is active
             if (rootFrame == null)
             {
-                _reactPage.OnCreate();
+                _reactPage.OnCreate(e.Arguments);
 
                 // Create a Frame to act as the navigation context and navigate to the first page
                 rootFrame = new Frame();

--- a/ReactWindows/ReactNative/DevSupport/DevSupportManager.cs
+++ b/ReactWindows/ReactNative/DevSupport/DevSupportManager.cs
@@ -31,7 +31,6 @@ namespace ReactNative.DevSupport
 
         private bool _isDevSupportEnabled = true;
         private bool _isShakeDetectorRegistered;
-        private bool _isUsingJsProxy;
 
         private ReactContext _currentContext;
         private RedBoxDialog _redBoxDialog;
@@ -76,9 +75,18 @@ namespace ReactNative.DevSupport
             }
             set
             {
-                _isDevSupportEnabled = value;
-                ReloadSettings();
+                if (value != _isDevSupportEnabled)
+                {
+                    _isDevSupportEnabled = value;
+                    ReloadSettings();
+                }
             }
+        }
+
+        public bool IsRemoteDebuggingEnabled
+        {
+            get;
+            set;
         }
 
         public string SourceMapUrl
@@ -191,12 +199,12 @@ namespace ReactNative.DevSupport
                         "Reload JavaScript",
                         HandleReloadJavaScript),
                     new DevOptionHandler(
-                        _isUsingJsProxy
+                        IsRemoteDebuggingEnabled
                             ? "Stop JS Remote Debugging"
                             : "Start JS Remote Debugging",
                         () =>
                         {
-                            _isUsingJsProxy = !_isUsingJsProxy;
+                            IsRemoteDebuggingEnabled = !IsRemoteDebuggingEnabled;
                             HandleReloadJavaScript();
                         }),
                     new DevOptionHandler(
@@ -270,14 +278,14 @@ namespace ReactNative.DevSupport
 
             HideRedboxDialog();
 
-            var message = !_isUsingJsProxy 
+            var message = !IsRemoteDebuggingEnabled
                 ? "Fetching JavaScript bundle." 
                 : "Connecting to remote debugger.";
 
             var progressDialog = new ProgressDialog("Please wait...", message);
             var dialogOperation = progressDialog.ShowAsync();
 
-            if (_isUsingJsProxy)
+            if (IsRemoteDebuggingEnabled)
             {
                 await ReloadJavaScriptInProxyMode(dialogOperation.Cancel, progressDialog.Token);
             }

--- a/ReactWindows/ReactNative/DevSupport/DisabledDevSupportManager.cs
+++ b/ReactWindows/ReactNative/DevSupport/DisabledDevSupportManager.cs
@@ -33,6 +33,12 @@ namespace ReactNative.DevSupport
             set;
         }
 
+        public bool IsRemoteDebuggingEnabled
+        {
+            get;
+            set;
+        }
+
         public string SourceMapUrl
         {
             get

--- a/ReactWindows/ReactNative/DevSupport/IDevSupportManager.cs
+++ b/ReactWindows/ReactNative/DevSupport/IDevSupportManager.cs
@@ -29,6 +29,11 @@ namespace ReactNative.DevSupport
         bool IsEnabled { get; set; }
 
         /// <summary>
+        /// Enables or disables remote debugging.
+        /// </summary>
+        bool IsRemoteDebuggingEnabled { get; set; }
+
+        /// <summary>
         /// The source map URL.
         /// </summary>
         string SourceMapUrl { get; }

--- a/ReactWindows/ReactNative/DevSupport/WebSocketJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/DevSupport/WebSocketJavaScriptExecutor.cs
@@ -4,6 +4,7 @@ using ReactNative.Bridge;
 using ReactNative.Collections;
 using System;
 using System.Collections.Generic;
+using System.Reactive.Disposables;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,12 +26,15 @@ namespace ReactNative.DevSupport
         private bool _connected;
         private DataWriter _messageWriter;
         private int _requestId;
+
+        private bool _isDisposed;
          
         public WebSocketJavaScriptExecutor()
         {
             _webSocket = new MessageWebSocket();
             _webSocket.Control.MessageType = SocketMessageType.Utf8;
             _webSocket.MessageReceived += OnMessageReceived;
+            _webSocket.Closed += OnClosed;
 
             _injectedObjects = new JObject();
             _callbacks = new Dictionary<int, TaskCompletionSource<JToken>>();
@@ -138,6 +142,7 @@ namespace ReactNative.DevSupport
 
         public void Dispose()
         {
+            _isDisposed = true;
             _messageWriter.Dispose();
             _webSocket.Dispose();
         }
@@ -190,9 +195,40 @@ namespace ReactNative.DevSupport
 
         private async Task SendMessageAsync(int requestId, string message)
         {
-            _messageWriter.WriteString(message);
-            await _messageWriter.StoreAsync();
-            // TODO: check result of `StoreAsync()`
+            if (!_isDisposed)
+            {
+                _messageWriter.WriteString(message);
+                await _messageWriter.StoreAsync();
+                // TODO: check result of `StoreAsync()`
+            }
+            else
+            {
+                DoCallback(requestId, null);
+            }
+        }
+
+        private void DoCallback(int replyId, JObject json)
+        {
+            var callback = default(TaskCompletionSource<JToken>);
+            if (_callbacks.TryGetValue(replyId, out callback))
+            {
+                var result = default(JToken);
+                if (json != null && json.TryGetValue("result", out result))
+                {
+                    if (result.Type == JTokenType.String)
+                    {
+                        callback.SetResult(JToken.Parse(result.Value<string>()));
+                    }
+                    else
+                    {
+                        callback.SetResult(result);
+                    }
+                }
+                else
+                {
+                    callback.SetResult(null);
+                }
+            }
         }
 
         private void OnMessageReceived(MessageWebSocket sender, MessageWebSocketMessageReceivedEventArgs args)
@@ -206,28 +242,14 @@ namespace ReactNative.DevSupport
                 if (json.ContainsKey("replyID"))
                 {
                     var replyId = json.Value<int>("replyID");
-                    var callback = default(TaskCompletionSource<JToken>);
-                    if (_callbacks.TryGetValue(replyId, out callback))
-                    {
-                        var result = default(JToken);
-                        if (json.TryGetValue("result", out result))
-                        {
-                            if (result.Type == JTokenType.String)
-                            {
-                                callback.SetResult(JToken.Parse(result.Value<string>()));
-                            }
-                            else
-                            {
-                                callback.SetResult(result);
-                            }
-                        }
-                        else
-                        {
-                            callback.SetResult(null);
-                        }
-                    }
+                    DoCallback(replyId, json);
                 }
             }
+        }
+
+        private void OnClosed(IWebSocket sender, WebSocketClosedEventArgs args)
+        {
+            Dispose();
         }
     }
 }

--- a/ReactWindows/ReactNative/DevSupport/WebSocketJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/DevSupport/WebSocketJavaScriptExecutor.cs
@@ -203,30 +203,10 @@ namespace ReactNative.DevSupport
             }
             else
             {
-                DoCallback(requestId, null);
-            }
-        }
-
-        private void DoCallback(int replyId, JObject json)
-        {
-            var callback = default(TaskCompletionSource<JToken>);
-            if (_callbacks.TryGetValue(replyId, out callback))
-            {
-                var result = default(JToken);
-                if (json != null && json.TryGetValue("result", out result))
+                var callback = default(TaskCompletionSource<JToken>);
+                if (_callbacks.TryGetValue(requestId, out callback))
                 {
-                    if (result.Type == JTokenType.String)
-                    {
-                        callback.SetResult(JToken.Parse(result.Value<string>()));
-                    }
-                    else
-                    {
-                        callback.SetResult(result);
-                    }
-                }
-                else
-                {
-                    callback.SetResult(null);
+                    callback.TrySetResult(JValue.CreateNull());
                 }
             }
         }
@@ -242,7 +222,26 @@ namespace ReactNative.DevSupport
                 if (json.ContainsKey("replyID"))
                 {
                     var replyId = json.Value<int>("replyID");
-                    DoCallback(replyId, json);
+                    var callback = default(TaskCompletionSource<JToken>);
+                    if (_callbacks.TryGetValue(replyId, out callback))
+                    {
+                        var result = default(JToken);
+                        if (json != null && json.TryGetValue("result", out result))
+                        {
+                            if (result.Type == JTokenType.String)
+                            {
+                                callback.TrySetResult(JToken.Parse(result.Value<string>()));
+                            }
+                            else
+                            {
+                                callback.TrySetResult(result);
+                            }
+                        }
+                        else
+                        {
+                            callback.TrySetResult(null);
+                        }
+                    }
                 }
             }
         }

--- a/ReactWindows/ReactNative/DevSupport/WebSocketJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/DevSupport/WebSocketJavaScriptExecutor.cs
@@ -4,7 +4,6 @@ using ReactNative.Bridge;
 using ReactNative.Collections;
 using System;
 using System.Collections.Generic;
-using System.Reactive.Disposables;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,7 +25,6 @@ namespace ReactNative.DevSupport
         private bool _connected;
         private DataWriter _messageWriter;
         private int _requestId;
-
         private bool _isDisposed;
          
         public WebSocketJavaScriptExecutor()

--- a/ReactWindows/ReactNative/ReactPage.cs
+++ b/ReactWindows/ReactNative/ReactPage.cs
@@ -191,8 +191,18 @@ namespace ReactNative
         {
             if (!string.IsNullOrEmpty(arguments))
             {
-                var json = JObject.Parse(arguments);
-                _reactInstanceManager.DevSupportManager.IsRemoteDebuggingEnabled = json.Value<bool>("remoteDebugging");
+                var args = arguments.Split(',');
+                if (args.Length % 2 != 0)
+                {
+                    throw new ArgumentException("Expected even number of arguments.", nameof(arguments));
+                }
+
+                var index = Array.IndexOf(args, "remoteDebugging");
+                var isRemoteDebuggingEnabled = default(bool);
+                if (index % 2 == 0 && bool.TryParse(args[index + 1], out isRemoteDebuggingEnabled))
+                {
+                    _reactInstanceManager.DevSupportManager.IsRemoteDebuggingEnabled = isRemoteDebuggingEnabled;
+                }
             }
         }
     }

--- a/ReactWindows/ReactNative/ReactPage.cs
+++ b/ReactWindows/ReactNative/ReactPage.cs
@@ -1,4 +1,5 @@
-﻿using ReactNative.Modules.Core;
+﻿using Newtonsoft.Json.Linq;
+using ReactNative.Modules.Core;
 using System;
 using System.Collections.Generic;
 using Windows.System;
@@ -79,17 +80,17 @@ namespace ReactNative
         /// <summary>
         /// The root view managed by the page.
         /// </summary>
-        public ReactRootView RootView
-        {
-            get;
-        }
+        public ReactRootView RootView { get; }
 
         /// <summary>
         /// Called when the application is first initialized.
         /// </summary>
-        public void OnCreate()
+        /// <param name="arguments">The launch arguments.</param>
+        public void OnCreate(string arguments)
         {
             RootView.Background = (Brush)Application.Current.Resources["ApplicationPageBackgroundThemeBrush"];
+
+            ApplyArguments(arguments);
             RootView.StartReactApplication(_reactInstanceManager, MainComponentName);
 
             SystemNavigationManager.GetForCurrentView().BackRequested += (sender, args) =>
@@ -171,7 +172,6 @@ namespace ReactNative
                 }
             }
         }
-        
 
         private IReactInstanceManager CreateReactInstanceManager()
         {
@@ -185,6 +185,15 @@ namespace ReactNative
 
             builder.Packages.AddRange(Packages);
             return builder.Build();
+        }
+
+        private void ApplyArguments(string arguments)
+        {
+            if (!string.IsNullOrEmpty(arguments))
+            {
+                var json = JObject.Parse(arguments);
+                _reactInstanceManager.DevSupportManager.IsRemoteDebuggingEnabled = json.Value<bool>("remoteDebugging");
+            }
         }
     }
 }

--- a/ReactWindows/ReactNative/ReactRootView.cs
+++ b/ReactWindows/ReactNative/ReactRootView.cs
@@ -52,9 +52,7 @@ namespace ReactNative
         /// <param name="reactInstanceManager">
         /// The React instance manager.
         /// </param>
-        /// <param name="moduleName">
-        /// The module name.
-        /// </param>
+        /// <param name="moduleName">The module name.</param>
         public void StartReactApplication(IReactInstanceManager reactInstanceManager, string moduleName)
         {
             DispatcherHelpers.AssertOnDispatcher();

--- a/local-cli/generator-windows/templates/src/App.xaml.cs
+++ b/local-cli/generator-windows/templates/src/App.xaml.cs
@@ -54,7 +54,7 @@ namespace <%= ns %>
             // just ensure that the window is active
             if (rootFrame == null)
             {
-                _reactPage.OnCreate();
+                _reactPage.OnCreate(e.Arguments);
 
                 // Create a Frame to act as the navigation context and navigate to the first page
                 rootFrame = new Frame();

--- a/local-cli/runWindows/runWindows.js
+++ b/local-cli/runWindows/runWindows.js
@@ -72,6 +72,7 @@ runWindows({
  *    emulator: Boolean - Deploy to the emulator
  *    device: Boolean - Deploy to a device
  *    target: String - Device GUID to deploy to
+ *    proxy: Boolean - Run using remote JS proxy
  */
 module.exports = {
   name: 'run-windows',
@@ -109,5 +110,9 @@ module.exports = {
     command: '--target [string]',
     description: 'Deploys the app to the specified GUID for a device.',
     default: '',
+  }, {
+    command: '--proxy',
+    description: 'Deploys the app in remote debugging mode.',
+    default: false,
   }]
 };

--- a/local-cli/runWindows/utils/WindowsStoreAppUtils.ps1
+++ b/local-cli/runWindows/utils/WindowsStoreAppUtils.ps1
@@ -153,7 +153,7 @@ function Start-Locally {
         [string] $ID, <# package.appxmanifest//Identity@name #>
 
         [Parameter(Mandatory=$false, Position=1, ValueFromPipelineByPropertyName=$true)]
-        [string] $args
+        [string[]] $argv
     )
     
     $package = Get-AppxPackage $ID
@@ -164,5 +164,6 @@ function Start-Locally {
 
     add-type -TypeDefinition $code
     $appActivator = new-object StoreAppRunner.ApplicationActivationManager
+    $args = [system.String]::Join(",", $argv)
     $appActivator.ActivateApplication($applicationUserModelId,$args,[StoreAppRunner.ActivateOptions]::None,[ref]0) | Out-Null
 }

--- a/local-cli/runWindows/utils/WindowsStoreAppUtils.ps1
+++ b/local-cli/runWindows/utils/WindowsStoreAppUtils.ps1
@@ -150,9 +150,8 @@ function Install-AppFromAppx {
 function Start-Locally {
     param(
         [Parameter(Mandatory=$true, Position=0, ValueFromPipelineByPropertyName=$true)]
-        [string] $ID <# package.appxmanifest//Identity@name #>
-    )
-    param(
+        [string] $ID, <# package.appxmanifest//Identity@name #>
+
         [Parameter(Mandatory=$true, Position=1, ValueFromPipelineByPropertyName=$true)]
         [string] $proxy
     )
@@ -165,6 +164,6 @@ function Start-Locally {
 
     add-type -TypeDefinition $code
     $appActivator = new-object StoreAppRunner.ApplicationActivationManager
-    $args = "{'remotingDebugging': " + $proxy + "}"
+    $args = "{'remoteDebugging': " + $proxy + "}"
     $appActivator.ActivateApplication($applicationUserModelId,$args,[StoreAppRunner.ActivateOptions]::None,[ref]0) | Out-Null
 }

--- a/local-cli/runWindows/utils/WindowsStoreAppUtils.ps1
+++ b/local-cli/runWindows/utils/WindowsStoreAppUtils.ps1
@@ -152,7 +152,11 @@ function Start-Locally {
         [Parameter(Mandatory=$true, Position=0, ValueFromPipelineByPropertyName=$true)]
         [string] $ID <# package.appxmanifest//Identity@name #>
     )
-
+    param(
+        [Parameter(Mandatory=$true, Position=1, ValueFromPipelineByPropertyName=$true)]
+        [string] $proxy
+    )
+    
     $package = Get-AppxPackage $ID
     $manifest = Get-appxpackagemanifest $package
     $applicationUserModelId = $package.PackageFamilyName + "!" + $manifest.package.applications.application.id
@@ -161,5 +165,6 @@ function Start-Locally {
 
     add-type -TypeDefinition $code
     $appActivator = new-object StoreAppRunner.ApplicationActivationManager
-    $appActivator.ActivateApplication($applicationUserModelId,$null,[StoreAppRunner.ActivateOptions]::None,[ref]0) | Out-Null
+    $args = "{'remotingDebugging': " + $proxy + "}"
+    $appActivator.ActivateApplication($applicationUserModelId,$args,[StoreAppRunner.ActivateOptions]::None,[ref]0) | Out-Null
 }

--- a/local-cli/runWindows/utils/WindowsStoreAppUtils.ps1
+++ b/local-cli/runWindows/utils/WindowsStoreAppUtils.ps1
@@ -152,8 +152,8 @@ function Start-Locally {
         [Parameter(Mandatory=$true, Position=0, ValueFromPipelineByPropertyName=$true)]
         [string] $ID, <# package.appxmanifest//Identity@name #>
 
-        [Parameter(Mandatory=$true, Position=1, ValueFromPipelineByPropertyName=$true)]
-        [string] $proxy
+        [Parameter(Mandatory=$false, Position=1, ValueFromPipelineByPropertyName=$true)]
+        [string] $args
     )
     
     $package = Get-AppxPackage $ID
@@ -164,6 +164,5 @@ function Start-Locally {
 
     add-type -TypeDefinition $code
     $appActivator = new-object StoreAppRunner.ApplicationActivationManager
-    $args = "{'remoteDebugging': " + $proxy + "}"
     $appActivator.ActivateApplication($applicationUserModelId,$args,[StoreAppRunner.ActivateOptions]::None,[ref]0) | Out-Null
 }

--- a/local-cli/runWindows/utils/deploy.js
+++ b/local-cli/runWindows/utils/deploy.js
@@ -75,7 +75,7 @@ function deployToDesktop(options) {
   const identity = appxManifest.root.children.filter(function (x) { return x.name === 'Identity'; })[0];
   const appName = identity.attributes.Name;
   const script = glob.sync(path.join(appPackageFolder, 'Add-AppDevPackage.ps1'))[0];
-
+  const args = {remoteDebugging: options.proxy};
 
   return new Promise(resolve => {
     console.log(chalk.green('Removing old version of the app'));
@@ -85,7 +85,7 @@ function deployToDesktop(options) {
     execSync(`powershell -ExecutionPolicy RemoteSigned Import-Module "${windowsStoreAppUtils}"; Install-App "${script}"`);
 
     console.log(chalk.green('Starting the app'));
-    execSync(`powershell -ExecutionPolicy RemoteSigned Import-Module "${windowsStoreAppUtils}"; Start-Locally ${appName} ${options.proxy}`);
+    execSync(`powershell -ExecutionPolicy RemoteSigned Import-Module "${windowsStoreAppUtils}"; Start-Locally ${appName} "${args}"`);
     resolve();
   });
 }

--- a/local-cli/runWindows/utils/deploy.js
+++ b/local-cli/runWindows/utils/deploy.js
@@ -85,7 +85,7 @@ function deployToDesktop(options) {
     execSync(`powershell -ExecutionPolicy RemoteSigned Import-Module "${windowsStoreAppUtils}"; Install-App "${script}"`);
 
     console.log(chalk.green('Starting the app'));
-    execSync(`powershell -ExecutionPolicy RemoteSigned Import-Module "${windowsStoreAppUtils}"; Start-Locally ${appName}`);
+    execSync(`powershell -ExecutionPolicy RemoteSigned Import-Module "${windowsStoreAppUtils}"; Start-Locally ${appName} ${options.proxy}`);
     resolve();
   });
 }

--- a/local-cli/runWindows/utils/deploy.js
+++ b/local-cli/runWindows/utils/deploy.js
@@ -75,7 +75,8 @@ function deployToDesktop(options) {
   const identity = appxManifest.root.children.filter(function (x) { return x.name === 'Identity'; })[0];
   const appName = identity.attributes.Name;
   const script = glob.sync(path.join(appPackageFolder, 'Add-AppDevPackage.ps1'))[0];
-  const args = {remoteDebugging: options.proxy};
+  const args = ["remoteDebugging", options.proxy];
+  const 
 
   return new Promise(resolve => {
     console.log(chalk.green('Removing old version of the app'));
@@ -85,7 +86,7 @@ function deployToDesktop(options) {
     execSync(`powershell -ExecutionPolicy RemoteSigned Import-Module "${windowsStoreAppUtils}"; Install-App "${script}"`);
 
     console.log(chalk.green('Starting the app'));
-    execSync(`powershell -ExecutionPolicy RemoteSigned Import-Module "${windowsStoreAppUtils}"; Start-Locally ${appName} "${args}"`);
+    execSync(`powershell -ExecutionPolicy RemoteSigned Import-Module "${windowsStoreAppUtils}"; Start-Locally ${appName} ${args}`);
     resolve();
   });
 }

--- a/local-cli/runWindows/utils/deploy.js
+++ b/local-cli/runWindows/utils/deploy.js
@@ -76,7 +76,6 @@ function deployToDesktop(options) {
   const appName = identity.attributes.Name;
   const script = glob.sync(path.join(appPackageFolder, 'Add-AppDevPackage.ps1'))[0];
   const args = ["remoteDebugging", options.proxy];
-  const 
 
   return new Promise(resolve => {
     console.log(chalk.green('Removing old version of the app'));


### PR DESCRIPTION
Tools like VS Code need to be able to launch the app from the command line with remote debugging enabled.  This change allows arguments to be passed from powershell to the app and down to the DevSupportManager.