### PR TITLE
fix(run-windows): Add loopback exemption for desktop apps

### DIFF
--- a/local-cli/runWindows/utils/deploy.js
+++ b/local-cli/runWindows/utils/deploy.js
@@ -84,6 +84,9 @@ function deployToDesktop(options) {
     console.log(chalk.green('Installing new version of the app'));
     execSync(`powershell -ExecutionPolicy RemoteSigned Import-Module "${windowsStoreAppUtils}"; Install-App "${script}"`);
 
+    const appFamilyName = execSync(`powershell -c $(Get-AppxPackage -Name ${appName}).PackageFamilyName`);
+    execSync(`CheckNetIsolation LoopbackExempt -a -n=${appFamilyName}`);
+
     console.log(chalk.green('Starting the app'));
     execSync(`powershell -ExecutionPolicy RemoteSigned Import-Module "${windowsStoreAppUtils}"; Start-Locally ${appName} ${args}`);
     resolve();


### PR DESCRIPTION
Ensure the loopback exemption is added for app for access to localhost (i.e., the packager server).

Fixes #515