### PR TITLE
fix(run-windows): prevent packager from crashing

### DIFF
--- a/local-cli/runWindows/runWindows.js
+++ b/local-cli/runWindows/runWindows.js
@@ -30,7 +30,6 @@ function runWindows(config, args, options) {
   const buildArch = options.arch ? options.arch : 'x86';
 
   try {
-    build.cleanSolution(options);
     build.buildSolution(slnFile, buildType, buildArch);
   } catch (e) {
     console.error(chalk.red(`Build failed with message ${e}. Check your build configuration.`));

--- a/local-cli/runWindows/utils/build.js
+++ b/local-cli/runWindows/utils/build.js
@@ -9,12 +9,6 @@ const shell = require('shelljs');
 const MSBuildTools = require('./msbuildtools');
 const Version = require('./version');
 
-function cleanSolution(options) {
-  const appPackagesPath = glob.sync(path.join(options.root, 'windows/*/AppPackages'));
-  console.log(chalk.green(`Cleaning AppPackages folder ${appPackagesPath}`));
-  shell.rm('-rf', appPackagesPath);
-}
-
 function buildSolution(slnFile, buildType, buildArch) {
   const minVersion = new Version(10, 0, 10586, 0);
   const allVersions = MSBuildTools.getAllAvailableUAPVersions();

--- a/local-cli/runWindows/utils/deploy.js
+++ b/local-cli/runWindows/utils/deploy.js
@@ -11,7 +11,9 @@ const parse = require('xml-parser');
 const WinAppDeployTool = require('./winappdeploytool');
 
 function getAppPackage(options) {
-  return glob.sync(path.join(options.root, 'windows/*/AppPackages/*'))[0];
+  const configuration = options.release ? 'Release' : 'Debug';
+  const arch = options.arch ? options.arch : 'x86';
+  return glob.sync(path.join(options.root, `windows/*/AppPackages/*_${arch}_${configuration}_*`))[0];
 }
 
 function getWindowsStoreAppUtils(options) {
@@ -96,10 +98,12 @@ function deployToDesktop(options) {
 function startServerInNewWindow(options) {
   return new Promise(resolve => {
     http.get('http://localhost:8081/status', res => {
-      if (res === 200) {
+      if (res.statusCode === 200) {
         console.log(chalk.green('React-Native Server already started'));
-        resolve();
-      }
+      } else {
+        console.log(chalk.red('React-Native Server not responding'));
+      }       
+      resolve();
     }).on('error', () => resolve(launchServer(options)));
   });
 }


### PR DESCRIPTION
Removing the AppPackages folder was causing the packager to crash. Avoiding the removal.

Fixes #517