### PR TITLE
fix(Image): Fixes race condition for subscribe/dispose

### DIFF
--- a/ReactWindows/ReactNative/Modules/Image/RefCountImageCache.cs
+++ b/ReactWindows/ReactNative/Modules/Image/RefCountImageCache.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reactive;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading;
@@ -56,8 +57,8 @@ namespace ReactNative.Modules.Image
         {
             private readonly RefCountImageCache _parent;
             private readonly ReplaySubject<Unit> _subject;
+            private readonly SingleAssignmentDisposable _subscription;
 
-            private IDisposable _subscription;
             private int _refCount = 1;
 
             public ImageReference(string uri, RefCountImageCache parent)
@@ -65,6 +66,8 @@ namespace ReactNative.Modules.Image
                 Uri = uri;
                 _parent = parent;
                 _subject = new ReplaySubject<Unit>(1);
+                _subscription = new SingleAssignmentDisposable();
+
                 InitializeImage();
             }
 
@@ -120,7 +123,7 @@ namespace ReactNative.Modules.Image
                         throw new Exception(pattern.EventArgs.ErrorMessage);
                     });
 
-                _subscription = openedObservable
+                _subscription.Disposable = openedObservable
                     .Merge(failedObservable)
                     .Subscribe(_subject);
             }

--- a/ReactWindows/ReactNative/Modules/Image/RefCountImageCache.cs
+++ b/ReactWindows/ReactNative/Modules/Image/RefCountImageCache.cs
@@ -57,6 +57,7 @@ namespace ReactNative.Modules.Image
         {
             private readonly RefCountImageCache _parent;
             private readonly ReplaySubject<Unit> _subject;
+            private readonly ObserverWrapper _observerWrapper;
             private readonly SingleAssignmentDisposable _subscription;
 
             private int _refCount = 1;
@@ -66,6 +67,7 @@ namespace ReactNative.Modules.Image
                 Uri = uri;
                 _parent = parent;
                 _subject = new ReplaySubject<Unit>(1);
+                _observerWrapper = new ObserverWrapper(_subject);
                 _subscription = new SingleAssignmentDisposable();
 
                 InitializeImage();
@@ -102,6 +104,7 @@ namespace ReactNative.Modules.Image
                     if (Interlocked.Decrement(ref _refCount) == 0)
                     {
                         _subscription.Dispose();
+                        _observerWrapper.Dispose();
                         _subject.Dispose();
                         _parent._cache.Remove(Uri);
                     }
@@ -125,7 +128,7 @@ namespace ReactNative.Modules.Image
 
                 _subscription.Disposable = openedObservable
                     .Merge(failedObservable)
-                    .Subscribe(_subject);
+                    .Subscribe(_observerWrapper);
             }
 
             private async void InitializeImage()
@@ -144,6 +147,52 @@ namespace ReactNative.Modules.Image
                         stream.Dispose();
                     }
                 });
+            }
+
+            class ObserverWrapper : IObserver<Unit>, IDisposable
+            {
+                private static readonly IObserver<Unit> s_nop = Observer.Create<Unit>(_ => { });
+
+                private readonly object _gate = new object();
+
+                private IObserver<Unit> _observer;
+
+                public ObserverWrapper(IObserver<Unit> inner)
+                {
+                    _observer = inner;
+                }
+
+                public void OnCompleted()
+                {
+                    lock (_gate)
+                    {
+                        _observer.OnCompleted();
+                    }
+                }
+
+                public void OnError(Exception error)
+                {
+                    lock (_gate)
+                    {
+                        _observer.OnCompleted();
+                    }
+                }
+
+                public void OnNext(Unit value)
+                {
+                    lock (_gate)
+                    {
+                        _observer.OnCompleted();
+                    }
+                }
+
+                public void Dispose()
+                {
+                    lock (_gate)
+                    {
+                        _observer = s_nop;
+                    }
+                }
             }
         }
     }

--- a/ReactWindows/ReactNative/Modules/Image/RefCountImageCache.cs
+++ b/ReactWindows/ReactNative/Modules/Image/RefCountImageCache.cs
@@ -174,7 +174,7 @@ namespace ReactNative.Modules.Image
                 {
                     lock (_gate)
                     {
-                        _observer.OnCompleted();
+                        _observer.OnError(error);
                     }
                 }
 
@@ -182,7 +182,7 @@ namespace ReactNative.Modules.Image
                 {
                     lock (_gate)
                     {
-                        _observer.OnCompleted();
+                        _observer.OnNext(value);
                     }
                 }
 


### PR DESCRIPTION
Because the subscription to the image events must occur on the dispatcher thread, the native module calls to ImageLoader are by neccessity asynchronous from the subscription to the image. To avoid a race condition where the image reference is disposed before the subscription occurs, this changeset adds a single-assignment disposable wrapper for the subscription.

Fixes #521