### PR TITLE
Fix move logic in UIImplementation.ManageChildren

### DIFF
--- a/ReactWindows/ReactNative/UIManager/UIImplementation.cs
+++ b/ReactWindows/ReactNative/UIManager/UIImplementation.cs
@@ -247,7 +247,7 @@ namespace ReactNative.UIManager
                 for (var i = 0; i < numToMove; ++i)
                 {
                     var moveFromIndex = moveFrom[i];
-                    var tagToMove = cssNodeToManage.GetChildAt(i).ReactTag;
+                    var tagToMove = cssNodeToManage.GetChildAt(moveFromIndex).ReactTag;
                     viewsToAdd[i] = new ViewAtIndex(tagToMove, moveTo[i]);
                     indicesToRemove[i] = moveFromIndex;
                     tagsToRemove[i] = tagToMove;


### PR DESCRIPTION
The wrong index is used to fetch a view while walking through the `moveFrom` array.