### PR TITLE
fix(RootViewHelper): Use VisualTreeHelper instead of explicit map shim

### DIFF
--- a/ReactWindows/ReactNative/Views/Split/ReactSplitViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Split/ReactSplitViewManager.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
 
 namespace ReactNative.Views.Split
 {
@@ -113,7 +114,7 @@ namespace ReactNative.Views.Split
                     $"'{Name}' only supports two child, the content and the pane.");
             }
 
-            child.SetParent(parent);
+            var source = new RelativeSource();
             var uiElementChild = child.As<UIElement>();
             if (index == 0)
             {
@@ -173,31 +174,18 @@ namespace ReactNative.Views.Split
 
         public override void RemoveAllChildren(SplitView parent)
         {
-            if (parent.Content != null)
-            {
-                parent.Content.RemoveParent();
-                parent.Content = null;
-            }
-            
-            if (parent.Pane != null)
-            {
-                parent.Pane.RemoveParent();
-                parent.Pane = null;
-            }
+            parent.Content = null;
+            parent.Pane = null;
         }
 
         public override void RemoveChildAt(SplitView parent, int index)
         {
             if (index == 0)
             {
-                var content = EnsureContent(parent);
-                content.RemoveParent();
                 parent.Content = null;
             }
             else if (index == 1)
             {
-                var pane = EnsurePane(parent);
-                pane.RemoveParent();
                 parent.Pane = null;
             }
             else

--- a/ReactWindows/ReactNative/Views/Split/ReactSplitViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Split/ReactSplitViewManager.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Data;
 
 namespace ReactNative.Views.Split
 {
@@ -114,7 +113,6 @@ namespace ReactNative.Views.Split
                     $"'{Name}' only supports two child, the content and the pane.");
             }
 
-            var source = new RelativeSource();
             var uiElementChild = child.As<UIElement>();
             if (index == 0)
             {

--- a/ReactWindows/ReactNative/Views/Text/ReactSpanViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactSpanViewManager.cs
@@ -60,7 +60,6 @@ namespace ReactNative.Views.Text
             var span = (Span)parent;
             var inline = (Inline)child;
             span.Inlines.Insert(index, inline);
-            inline.SetParent(span);
         }
 
         /// <summary>
@@ -122,11 +121,6 @@ namespace ReactNative.Views.Text
         public void RemoveAllChildren(DependencyObject parent)
         {
             var span = (Span)parent;
-            foreach (var inline in span.Inlines)
-            {
-                inline.RemoveParent();
-            }
-
             span.Inlines.Clear();
         }
 
@@ -138,7 +132,6 @@ namespace ReactNative.Views.Text
         public void RemoveChildAt(DependencyObject parent, int index)
         {
             var span = (Span)parent;
-            span.Inlines[index].RemoveParent();
             span.Inlines.RemoveAt(index);
         }
 

--- a/ReactWindows/ReactNative/Views/Text/ReactTextViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactTextViewManager.cs
@@ -56,7 +56,6 @@ namespace ReactNative.Views.Text
                 };
             }
 
-            inlineChild.SetParent(parent);
             parent.Blocks.OfType<Paragraph>().First().Inlines.Insert(index, inlineChild);
         }
 
@@ -97,11 +96,6 @@ namespace ReactNative.Views.Text
         public override void RemoveAllChildren(RichTextBlock parent)
         {
             var inlines = parent.Blocks.OfType<Paragraph>().First().Inlines;
-            foreach (var inline in inlines)
-            {
-                inline.RemoveParent();
-            }
-
             inlines.Clear();
         }
 
@@ -113,7 +107,6 @@ namespace ReactNative.Views.Text
         public override void RemoveChildAt(RichTextBlock parent, int index)
         {
             var inlines = parent.Blocks.OfType<Paragraph>().First().Inlines;
-            inlines[index].RemoveParent();
             inlines.RemoveAt(index);
         }
 


### PR DESCRIPTION
VisualTreeHelper is able to find the parent dependency object in cases where the FrameworkElement.Parent property may be null. This is a useful way to ensure we can find the RootView for measurement.

Hacking this helper, however, breaks certain views like SplitView, which currently depend on the pointer not being captured by React to close the view when the lightweight Rect layer is overlayed adjacent to the pane. For now, only using the VisualTreeHelper in the root view search case, however we may want to use it more generally and have a better "opt-out" mechanism for view managers like SplitView.