### PR TITLE
fix(async): Task.FromResult -> Task.CompletedTask where possible

### DIFF
--- a/ReactWindows/ReactNative.Tests/Bridge/NativeModuleBaseTests.cs
+++ b/ReactWindows/ReactNative.Tests/Bridge/NativeModuleBaseTests.cs
@@ -394,7 +394,7 @@ namespace ReactNative.Tests.Bridge
             [ReactMethod]
             public Task Foo(ICallback callback)
             {
-                return Task.FromResult(true);
+                return Task.CompletedTask;
             }
         }
 
@@ -411,7 +411,7 @@ namespace ReactNative.Tests.Bridge
             [ReactMethod]
             public Task Foo(IPromise promise)
             {
-                return Task.FromResult(true);
+                return Task.CompletedTask;
             }
         }
 
@@ -428,7 +428,7 @@ namespace ReactNative.Tests.Bridge
             [ReactMethod]
             public Task Foo()
             {
-                return Task.FromResult(true);
+                return Task.CompletedTask;
             }
         }
 

--- a/ReactWindows/ReactNative.Tests/Internal/JavaScriptHelpers.cs
+++ b/ReactWindows/ReactNative.Tests/Internal/JavaScriptHelpers.cs
@@ -16,7 +16,7 @@ namespace ReactNative.Tests
             return Run((executor, jsQueueThread) =>
             {
                 action(executor, jsQueueThread);
-                return Task.FromResult(true);
+                return Task.CompletedTask;
             });
         }
 

--- a/ReactWindows/ReactNative.Tests/Modules/Network/TaskCancellationManagerTests.cs
+++ b/ReactWindows/ReactNative.Tests/Modules/Network/TaskCancellationManagerTests.cs
@@ -21,7 +21,7 @@ namespace ReactNative.Tests.Modules.Network
         public void TaskCancellationManager_CancelledAfterCompleted()
         {
             var mgr = new TaskCancellationManager<int>();
-            mgr.Add(42, _ => Task.FromResult(true));
+            mgr.Add(42, _ => Task.CompletedTask);
             mgr.Cancel(42);
 
             // Not throwing implies success

--- a/ReactWindows/ReactNative/Bridge/JavaScriptBundleLoader.cs
+++ b/ReactWindows/ReactNative/Bridge/JavaScriptBundleLoader.cs
@@ -168,7 +168,7 @@ namespace ReactNative.Bridge
 
             public override Task InitializeAsync()
             {
-                return Task.FromResult(false);
+                return Task.CompletedTask;
             }
 
             public override void LoadScript(IReactBridge executor)

--- a/ReactWindows/ReactNative/DevSupport/DevSupportManager.cs
+++ b/ReactWindows/ReactNative/DevSupport/DevSupportManager.cs
@@ -446,7 +446,7 @@ namespace ReactNative.DevSupport
         private Task ReloadJavaScriptFromFileAsync(CancellationToken token)
         {
             _reactInstanceCommandsHandler.OnBundleFileReloadRequest();
-            return Task.FromResult(true);
+            return Task.CompletedTask;
         }
 
         private void RegisterDevOptionsMenuTriggers()

--- a/ReactWindows/ReactNative/Modules/StatusBar/NopStatusBar.cs
+++ b/ReactWindows/ReactNative/Modules/StatusBar/NopStatusBar.cs
@@ -21,12 +21,12 @@ namespace ReactNative.Modules.StatusBar
 
         public IAsyncAction HideAsync()
         {
-            return Task.FromResult(false).AsAsyncAction();
+            return Task.CompletedTask.AsAsyncAction();
         }
 
         public IAsyncAction ShowAsync()
         {
-            return Task.FromResult(false).AsAsyncAction();
+            return Task.CompletedTask.AsAsyncAction();
         }
     }
 }


### PR DESCRIPTION
Avoid allocating a new task if not necessary.