### PR TITLE
fix(Text): Add separate layout thread with dispatcher access

### DIFF
--- a/ReactWindows/ReactNative.Tests/Bridge/Queue/MessageQueueThreadTests.cs
+++ b/ReactWindows/ReactNative.Tests/Bridge/Queue/MessageQueueThreadTests.cs
@@ -26,6 +26,7 @@ namespace ReactNative.Tests.Bridge.Queue
         public void MessageQueueThread_CreateUiThread_ThrowsNotSupported()
         {
             AssertEx.Throws<NotSupportedException>(() => MessageQueueThreadSpec.Create("ui", MessageQueueThreadKind.DispatcherThread));
+            AssertEx.Throws<NotSupportedException>(() => MessageQueueThreadSpec.Create("layout", MessageQueueThreadKind.LayoutThread));
         }
 
         [TestMethod]
@@ -33,12 +34,14 @@ namespace ReactNative.Tests.Bridge.Queue
         {
             var thrown = 0;
             var uiThread = await CallOnDispatcherAsync(() => MessageQueueThread.Create(MessageQueueThreadSpec.DispatcherThreadSpec, ex => thrown++));
+            var layoutThread = await CallOnDispatcherAsync(() => MessageQueueThread.Create(MessageQueueThreadSpec.LayoutThreadSpec, ex => thrown++));
             var backgroundThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("background", MessageQueueThreadKind.BackgroundSingleThread), ex => thrown++);
             var taskPoolThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("any", MessageQueueThreadKind.BackgroundAnyThread), ex => thrown++);
 
             var queueThreads = new[]
             {
                 uiThread,
+                layoutThread,
                 backgroundThread,
                 taskPoolThread
             };
@@ -69,12 +72,14 @@ namespace ReactNative.Tests.Bridge.Queue
             });
 
             var uiThread = await CallOnDispatcherAsync(() => MessageQueueThread.Create(MessageQueueThreadSpec.DispatcherThreadSpec, handler));
+            var layoutThread = await CallOnDispatcherAsync(() => MessageQueueThread.Create(MessageQueueThreadSpec.LayoutThreadSpec, handler));
             var backgroundThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("background", MessageQueueThreadKind.BackgroundSingleThread), handler);
             var taskPoolThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("any", MessageQueueThreadKind.BackgroundAnyThread), handler);
 
             var queueThreads = new[]
             {
                 uiThread,
+                layoutThread,
                 backgroundThread,
                 taskPoolThread
             };
@@ -90,9 +95,10 @@ namespace ReactNative.Tests.Bridge.Queue
         [TestMethod]
         public async Task MessageQueueThread_OneAtATime()
         {
-            var uiThread = await CallOnDispatcherAsync(() => MessageQueueThread.Create(MessageQueueThreadSpec.DispatcherThreadSpec, ex => { Assert.Fail(); }));
-            var backgroundThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("background", MessageQueueThreadKind.BackgroundSingleThread), ex => { Assert.Fail(); });
-            var taskPoolThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("any", MessageQueueThreadKind.BackgroundAnyThread), ex => { Assert.Fail(); });
+            var uiThread = await CallOnDispatcherAsync(() => MessageQueueThread.Create(MessageQueueThreadSpec.DispatcherThreadSpec, ex => Assert.Fail()));
+            var layoutThread = await CallOnDispatcherAsync(() => MessageQueueThread.Create(MessageQueueThreadSpec.LayoutThreadSpec, ex => Assert.Fail()));
+            var backgroundThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("background", MessageQueueThreadKind.BackgroundSingleThread), ex => Assert.Fail());
+            var taskPoolThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("any", MessageQueueThreadKind.BackgroundAnyThread), ex => Assert.Fail());
 
             var enter = new AutoResetEvent(false);
             var exit = new AutoResetEvent(false);
@@ -100,6 +106,7 @@ namespace ReactNative.Tests.Bridge.Queue
             var queueThreads = new[] 
             {
                 uiThread,
+                layoutThread,
                 backgroundThread,
                 taskPoolThread
             };
@@ -124,13 +131,15 @@ namespace ReactNative.Tests.Bridge.Queue
         [TestMethod]
         public async Task MessageQueueThread_Dispose()
         {
-            var uiThread = await CallOnDispatcherAsync(() => MessageQueueThread.Create(MessageQueueThreadSpec.DispatcherThreadSpec, ex => { Assert.Fail(); }));
-            var backgroundThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("background", MessageQueueThreadKind.BackgroundSingleThread), ex => { Assert.Fail(); });
-            var taskPoolThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("any", MessageQueueThreadKind.BackgroundAnyThread), ex => { Assert.Fail(); });
+            var uiThread = await CallOnDispatcherAsync(() => MessageQueueThread.Create(MessageQueueThreadSpec.DispatcherThreadSpec, ex => Assert.Fail()));
+            var layoutThread = await CallOnDispatcherAsync(() => MessageQueueThread.Create(MessageQueueThreadSpec.LayoutThreadSpec, ex => Assert.Fail()));
+            var backgroundThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("background", MessageQueueThreadKind.BackgroundSingleThread), ex => Assert.Fail());
+            var taskPoolThread = MessageQueueThread.Create(MessageQueueThreadSpec.Create("any", MessageQueueThreadKind.BackgroundAnyThread), ex => Assert.Fail());
 
             var queueThreads = new[]
             {
                 uiThread,
+                layoutThread,
                 backgroundThread,
                 taskPoolThread
             };

--- a/ReactWindows/ReactNative/Bridge/Queue/IReactQueueConfiguration.cs
+++ b/ReactWindows/ReactNative/Bridge/Queue/IReactQueueConfiguration.cs
@@ -16,6 +16,11 @@ namespace ReactNative.Bridge.Queue
         IMessageQueueThread DispatcherQueueThread { get; }
 
         /// <summary>
+        /// The layout thread.
+        /// </summary>
+        IMessageQueueThread LayoutQueueThread { get; }
+
+        /// <summary>
         /// The native modules thread.
         /// </summary>
         IMessageQueueThread NativeModulesQueueThread { get; }

--- a/ReactWindows/ReactNative/Bridge/Queue/MessageQueueThread.cs
+++ b/ReactWindows/ReactNative/Bridge/Queue/MessageQueueThread.cs
@@ -7,6 +7,7 @@ using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading;
 using System.Threading.Tasks;
+using Windows.ApplicationModel.Core;
 using Windows.Foundation;
 using Windows.System.Threading;
 using Windows.UI.Core;
@@ -124,7 +125,9 @@ namespace ReactNative.Bridge.Queue
             switch (spec.Kind)
             {
                 case MessageQueueThreadKind.DispatcherThread:
-                    return new DispatcherMessageQueueThread(spec.Name, handler);
+                case MessageQueueThreadKind.LayoutThread:
+                    var isSecondary = spec.Kind == MessageQueueThreadKind.LayoutThread;
+                    return new DispatcherMessageQueueThread(spec.Name, handler, isSecondary);
                 case MessageQueueThreadKind.BackgroundSingleThread:
                     return new SingleBackgroundMessageQueueThread(spec.Name, handler);
                 case MessageQueueThreadKind.BackgroundAnyThread:
@@ -137,20 +140,28 @@ namespace ReactNative.Bridge.Queue
 
         class DispatcherMessageQueueThread : MessageQueueThread
         {
+            private static readonly CoreApplicationView s_secondaryView = CoreApplication.CreateNewView();
             private static readonly IObserver<Action> s_nop = Observer.Create<Action>(_ => { });
 
+            private readonly bool _isSecondary;
             private readonly Subject<Action> _actionSubject;
             private readonly IDisposable _subscription;
 
             private IObserver<Action> _actionObserver;
 
-            public DispatcherMessageQueueThread(string name, Action<Exception> handler)
+            public DispatcherMessageQueueThread(string name, Action<Exception> handler, bool isSecondary)
                 : base(name)
             {
+                _isSecondary = isSecondary;
                 _actionSubject = new Subject<Action>();
                 _actionObserver = _actionSubject;
+
+                var dispatcher = isSecondary
+                    ? s_secondaryView.Dispatcher
+                    : CoreApplication.GetCurrentView().Dispatcher;
+
                 _subscription = _actionSubject
-                    .ObserveOnDispatcher()
+                    .ObserveOn(dispatcher)
                     .Subscribe(action =>
                     {
                         try
@@ -171,7 +182,7 @@ namespace ReactNative.Bridge.Queue
 
             protected override bool IsOnThreadCore()
             {
-                return CoreWindow.GetForCurrentThread().Dispatcher != null;
+                return GetApplicationView() != null;
             }
 
             protected override void Dispose(bool disposing)
@@ -180,6 +191,20 @@ namespace ReactNative.Bridge.Queue
                 Interlocked.Exchange(ref _actionObserver, s_nop);
                 _actionSubject.Dispose();
                 _subscription.Dispose();
+            }
+
+            private CoreApplicationView GetApplicationView()
+            {
+                if (_isSecondary && s_secondaryView.Dispatcher.HasThreadAccess)
+                {
+                    return s_secondaryView;
+                }
+                else if (!_isSecondary)
+                {
+                    return CoreApplication.GetCurrentView();
+                }
+
+                return null;
             }
         }
 

--- a/ReactWindows/ReactNative/Bridge/Queue/MessageQueueThreadKind.cs
+++ b/ReactWindows/ReactNative/Bridge/Queue/MessageQueueThreadKind.cs
@@ -9,6 +9,11 @@
         /// Dispatcher thread type.
         /// </summary>
         DispatcherThread,
+
+        /// <summary>
+        /// Layout thread type.
+        /// </summary>
+        LayoutThread,
         
         /// <summary>
         /// Single background thread type.

--- a/ReactWindows/ReactNative/Bridge/Queue/MessageQueueThreadSpec.cs
+++ b/ReactWindows/ReactNative/Bridge/Queue/MessageQueueThreadSpec.cs
@@ -29,6 +29,11 @@ namespace ReactNative.Bridge.Queue
         public static MessageQueueThreadSpec DispatcherThreadSpec { get; } = new MessageQueueThreadSpec(MessageQueueThreadKind.DispatcherThread, "main_ui");
 
         /// <summary>
+        /// Singleton layout <see cref="IMessageQueueThread"/> specification. 
+        /// </summary>
+        public static MessageQueueThreadSpec LayoutThreadSpec { get; } = new MessageQueueThreadSpec(MessageQueueThreadKind.LayoutThread, "layout");
+
+        /// <summary>
         /// Factory for creating <see cref="MessageQueueThreadSpec"/>s.
         /// </summary>
         /// <param name="name">The name.</param>
@@ -38,7 +43,12 @@ namespace ReactNative.Bridge.Queue
         {
             if (kind == MessageQueueThreadKind.DispatcherThread)
             {
-                throw new NotSupportedException("Use the singleton MainUiThreadSpec instance.");
+                throw new NotSupportedException("Use the singleton DispatcherThreadSpec instance.");
+            }
+
+            if (kind == MessageQueueThreadKind.LayoutThread)
+            {
+                throw new NotSupportedException("Use the singleton LayoutThreadSpec instance.");
             }
 
             return new MessageQueueThreadSpec(kind, name);

--- a/ReactWindows/ReactNative/Bridge/Queue/ReactQueueConfiguration.cs
+++ b/ReactWindows/ReactNative/Bridge/Queue/ReactQueueConfiguration.cs
@@ -11,15 +11,18 @@ namespace ReactNative.Bridge.Queue
     class ReactQueueConfiguration : IReactQueueConfiguration
     {
         private readonly MessageQueueThread _dispatcherQueueThread;
+        private readonly MessageQueueThread _layoutQueueThread;
         private readonly MessageQueueThread _nativeModulesQueueThread;
         private readonly MessageQueueThread _jsQueueThread;
 
         private ReactQueueConfiguration(
             MessageQueueThread dispatcherQueueThread,
+            MessageQueueThread layoutQueueThread,
             MessageQueueThread nativeModulesQueueThread,
             MessageQueueThread jsQueueThread)
         {
             _dispatcherQueueThread = dispatcherQueueThread;
+            _layoutQueueThread = layoutQueueThread;
             _nativeModulesQueueThread = nativeModulesQueueThread;
             _jsQueueThread = jsQueueThread;
         }
@@ -32,6 +35,17 @@ namespace ReactNative.Bridge.Queue
             get
             {
                 return _dispatcherQueueThread;
+            }
+        }
+
+        /// <summary>
+        /// The layout queue thread.
+        /// </summary>
+        public IMessageQueueThread LayoutQueueThread
+        {
+            get
+            {
+                return _layoutQueueThread;
             }
         }
 
@@ -67,6 +81,7 @@ namespace ReactNative.Bridge.Queue
         public void Dispose()
         {
             _dispatcherQueueThread.Dispose();
+            _layoutQueueThread.Dispose();
             _nativeModulesQueueThread.Dispose();
             _jsQueueThread.Dispose();
         }
@@ -84,6 +99,9 @@ namespace ReactNative.Bridge.Queue
             var dispatcherThreadSpec = MessageQueueThreadSpec.DispatcherThreadSpec;
             var dispatcherThread = MessageQueueThread.Create(dispatcherThreadSpec, exceptionHandler);
 
+            var layoutThreadSpec = MessageQueueThreadSpec.LayoutThreadSpec;
+            var layoutThread = MessageQueueThread.Create(layoutThreadSpec, exceptionHandler);
+
             var jsThread = spec.JSQueueThreadSpec != dispatcherThreadSpec
                 ? MessageQueueThread.Create(spec.JSQueueThreadSpec, exceptionHandler)
                 : dispatcherThread;
@@ -92,7 +110,7 @@ namespace ReactNative.Bridge.Queue
                 ? MessageQueueThread.Create(spec.NativeModulesQueueThreadSpec, exceptionHandler)
                 : dispatcherThread;
 
-            return new ReactQueueConfiguration(dispatcherThread, nativeModulesThread, jsThread);
+            return new ReactQueueConfiguration(dispatcherThread, layoutThread, nativeModulesThread, jsThread);
         }
     }
 }

--- a/ReactWindows/ReactNative/Bridge/Queue/ReactQueueConfigurationSpec.cs
+++ b/ReactWindows/ReactNative/Bridge/Queue/ReactQueueConfigurationSpec.cs
@@ -18,6 +18,14 @@ namespace ReactNative.Bridge.Queue
         }
 
         /// <summary>
+        /// The Layout <see cref="IMessageQueueThread"/> specification. 
+        /// </summary>
+        public MessageQueueThreadSpec LayoutQueueThreadSpec
+        {
+            get;
+        }
+
+        /// <summary>
         /// The native modules <see cref="IMessageQueueThread"/> specification.
         /// </summary>
         public MessageQueueThreadSpec NativeModulesQueueThreadSpec
@@ -32,7 +40,7 @@ namespace ReactNative.Bridge.Queue
         {
             get;
         }
-        
+
         /// <summary>
         /// The default <see cref="ReactQueueConfigurationSpec"/> instance.
         /// </summary>
@@ -42,8 +50,8 @@ namespace ReactNative.Bridge.Queue
         {
             return new Builder()
             {
-                JSQueueThreadSpec = MessageQueueThreadSpec.Create("js", MessageQueueThreadKind.BackgroundSingleThread),
                 NativeModulesQueueThreadSpec = MessageQueueThreadSpec.Create("native_modules", MessageQueueThreadKind.BackgroundAnyThread),
+                JSQueueThreadSpec = MessageQueueThreadSpec.Create("js", MessageQueueThreadKind.BackgroundSingleThread),
             }
             .Build();
         }
@@ -81,7 +89,7 @@ namespace ReactNative.Bridge.Queue
                 {
                     if (_jsQueueThreadSpec != null)
                     {
-                        throw new InvalidOperationException("Setting native modules queue thread spec multiple times!");
+                        throw new InvalidOperationException("Setting JavaScript queue thread spec multiple times!");
                     }
 
                     _jsQueueThreadSpec = value;

--- a/ReactWindows/ReactNative/Bridge/ReactContext.cs
+++ b/ReactWindows/ReactNative/Bridge/ReactContext.cs
@@ -207,8 +207,8 @@ namespace ReactNative.Bridge
         }
 
         /// <summary>
-        /// Asserts that the current thread is on the React instance native
-        /// modules queue thread.
+        /// Asserts that the current thread is on the React instance dispatcher
+        /// queue thread.
         /// </summary>
         public void AssertOnDispatcherQueueThread()
         {
@@ -224,6 +224,40 @@ namespace ReactNative.Bridge
         {
             AssertReactInstance();
             _reactInstance.QueueConfiguration.DispatcherQueueThread.RunOnQueue(action);
+        }
+
+        /// <summary>
+        /// Checks if the current thread is on the React instance layout
+        /// queue thread.
+        /// </summary>
+        /// <returns>
+        /// <b>true</b> if the call is from the layout queue thread,
+        ///  <b>false</b> otherwise.
+        /// </returns>
+        public bool IsOnLayoutQueueThread()
+        {
+            AssertReactInstance();
+            return _reactInstance.QueueConfiguration.LayoutQueueThread.IsOnThread();
+        }
+
+        /// <summary>
+        /// Asserts that the current thread is on the React instance layout
+        /// queue thread.
+        /// </summary>
+        public void AssertOnLayoutQueueThread()
+        {
+            AssertReactInstance();
+            _reactInstance.QueueConfiguration.LayoutQueueThread.AssertOnThread();
+        }
+
+        /// <summary>
+        /// Enqueues an action on the layout queue thread.
+        /// </summary>
+        /// <param name="action">The action.</param>
+        public void RunOnLayoutQueueThread(Action action)
+        {
+            AssertReactInstance();
+            _reactInstance.QueueConfiguration.LayoutQueueThread.RunOnQueue(action);
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative/UIManager/UIManagerModule.cs
+++ b/ReactWindows/ReactNative/UIManager/UIManagerModule.cs
@@ -112,11 +112,11 @@ namespace ReactNative.UIManager
                 var newWidth = args.NewSize.Width;
                 var newHeight = args.NewSize.Height;
 
-                Context.RunOnNativeModulesQueueThread(() =>
+                Context.RunOnLayoutQueueThread(() =>
                 {
                     if (currentCount == resizeCount)
                     {
-                        Context.AssertOnNativeModulesQueueThread();
+                        Context.AssertOnLayoutQueueThread();
                         _uiImplementation.UpdateRootNodeSize(tag, newWidth, newHeight, _eventDispatcher);
                     }
                 });
@@ -134,7 +134,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void removeRootView(int rootViewTag)
         {
-            _uiImplementation.RemoveRootView(rootViewTag);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.RemoveRootView(rootViewTag));
         }
 
         /// <summary>
@@ -147,7 +148,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void createView(int tag, string className, int rootViewTag, JObject props)
         {
-            _uiImplementation.CreateView(tag, className, rootViewTag, props);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.CreateView(tag, className, rootViewTag, props));
         }
 
         /// <summary>
@@ -159,7 +161,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void updateView(int tag, string className, JObject props)
         {
-            _uiImplementation.UpdateView(tag, className, props);
+            Context.RunOnLayoutQueueThread(() =>
+            _uiImplementation.UpdateView(tag, className, props));
         }
 
         /// <summary>
@@ -191,13 +194,14 @@ namespace ReactNative.UIManager
             int[] addAtIndices,
             int[] removeFrom)
         {
-            _uiImplementation.ManageChildren(
-                viewTag,
-                moveFrom,
-                moveTo,
-                addChildTags,
-                addAtIndices,
-                removeFrom);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.ManageChildren(
+                    viewTag,
+                    moveFrom,
+                    moveTo,
+                    addChildTags,
+                    addAtIndices,
+                    removeFrom));
         }
 
         /// <summary>
@@ -213,7 +217,8 @@ namespace ReactNative.UIManager
             int viewTag,
             int[] childrenTags)
         {
-            _uiImplementation.SetChildren(viewTag, childrenTags);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.SetChildren(viewTag, childrenTags));
         }
 
         /// <summary>
@@ -229,7 +234,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void replaceExistingNonRootView(int oldTag, int newTag)
         {
-            _uiImplementation.ReplaceExistingNonRootView(oldTag, newTag);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.ReplaceExistingNonRootView(oldTag, newTag));
         }
 
         /// <summary>
@@ -240,7 +246,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void removeSubviewsFromContainerWithID(int containerTag)
         {
-            _uiImplementation.RemoveSubviewsFromContainerWithID(containerTag);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.RemoveSubviewsFromContainerWithID(containerTag));
         }
 
         /// <summary>
@@ -252,7 +259,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void measure(int reactTag, ICallback callback)
         {
-            _uiImplementation.Measure(reactTag, callback);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.Measure(reactTag, callback));
         }
 
         /// <summary>
@@ -264,7 +272,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void measureInWindow(int reactTag, ICallback callback)
         {
-            _uiImplementation.MeasureInWindow(reactTag, callback);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.MeasureInWindow(reactTag, callback));
         }
 
         /// <summary>
@@ -289,7 +298,8 @@ namespace ReactNative.UIManager
             ICallback errorCallback,
             ICallback successCallback)
         {
-            _uiImplementation.MeasureLayout(tag, ancestorTag, errorCallback, successCallback);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.MeasureLayout(tag, ancestorTag, errorCallback, successCallback));
         }
 
         /// <summary>
@@ -312,7 +322,8 @@ namespace ReactNative.UIManager
             ICallback errorCallback,
             ICallback successCallback)
         {
-            _uiImplementation.MeasureLayoutRelativeToParent(tag, errorCallback, successCallback);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.MeasureLayoutRelativeToParent(tag, errorCallback, successCallback));
         }
 
         /// <summary>
@@ -335,11 +346,12 @@ namespace ReactNative.UIManager
             JArray point,
             ICallback callback)
         {
-            _uiImplementation.FindSubviewIn(
-                reactTag,
-                point[0].Value<double>(),
-                point[1].Value<double>(),
-                callback);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.FindSubviewIn(
+                    reactTag,
+                    point[0].Value<double>(),
+                    point[1].Value<double>(),
+                    callback));
         }
 
         /// <summary>
@@ -352,7 +364,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void setJSResponder(int reactTag, bool blockNativeResponder)
         {
-            _uiImplementation.SetJavaScriptResponder(reactTag, blockNativeResponder);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.SetJavaScriptResponder(reactTag, blockNativeResponder));
         }
 
         /// <summary>
@@ -361,7 +374,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void clearJSResponder()
         {
-            _uiImplementation.ClearJavaScriptResponder();
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.ClearJavaScriptResponder());
         }
 
         /// <summary>
@@ -373,7 +387,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void dispatchViewManagerCommand(int reactTag, int commandId, JArray commandArgs)
         {
-            _uiImplementation.DispatchViewManagerCommand(reactTag, commandId, commandArgs);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.DispatchViewManagerCommand(reactTag, commandId, commandArgs));
         }
 
         /// <summary>
@@ -395,7 +410,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void showPopupMenu(int reactTag, string[] items, ICallback error, ICallback success)
         {
-            _uiImplementation.ShowPopupMenu(reactTag, items, error, success);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.ShowPopupMenu(reactTag, items, error, success));
         }
 
         /// <summary>
@@ -416,7 +432,8 @@ namespace ReactNative.UIManager
         [ReactMethod]
         public void configureNextLayoutAnimation(JObject config, ICallback success, ICallback error)
         {
-            _uiImplementation.ConfigureNextLayoutAnimation(config, success, error);
+            Context.RunOnLayoutQueueThread(() =>
+                _uiImplementation.ConfigureNextLayoutAnimation(config, success, error));
         }
 
         #endregion
@@ -464,12 +481,15 @@ namespace ReactNative.UIManager
         {
             var batchId = _batchId++;
 
-            using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "onBatchCompleteUI")
-                .With("BatchId", batchId)
-                .Start())
+            Context.RunOnLayoutQueueThread(() =>
             {
-                _uiImplementation.DispatchViewUpdates(_eventDispatcher, batchId);
-            }
+                using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "onBatchCompleteUI")
+                    .With("BatchId", batchId)
+                    .Start())
+                {
+                    _uiImplementation.DispatchViewUpdates(_eventDispatcher, batchId);
+                }
+            });
         }
 
         #endregion

--- a/ReactWindows/ReactNative/UIManager/UIViewOperationQueue.cs
+++ b/ReactWindows/ReactNative/UIManager/UIViewOperationQueue.cs
@@ -47,7 +47,7 @@ namespace ReactNative.UIManager
         /// </returns>
         public bool IsEmpty()
         {
-            lock (_operations)
+            lock (_gate)
             {
                 return _operations.Count == 0;
             }
@@ -369,14 +369,14 @@ namespace ReactNative.UIManager
         /// <param name="batchId">The batch identifier.</param>
         internal void DispatchViewUpdates(int batchId)
         {
-            var operations = _operations.Count == 0 ? null : _operations;
-            if (operations != null)
-            {
-                _operations = new List<Action>();
-            }
-
             lock (_gate)
             {
+                var operations = _operations.Count == 0 ? null : _operations;
+                if (operations != null)
+                {
+                    _operations = new List<Action>();
+                }
+
                 _batches.Add(() =>
                 {
                     using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "DispatchUI")

--- a/ReactWindows/ReactNative/Views/Text/ReactTextShadowNode.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactTextShadowNode.cs
@@ -40,20 +40,6 @@ namespace ReactNative.Views.Text
         }
 
         /// <summary>
-        /// Instantiates the <see cref="ReactTextShadowNode"/>.
-        /// </summary>
-        /// <param name="isRoot">
-        /// A flag signaling whether or not the node is the root node.
-        /// </param>
-        public ReactTextShadowNode(bool isRoot)
-        {
-            if (isRoot)
-            {
-                MeasureFunction = MeasureText;
-            }
-        }
-
-        /// <summary>
         /// Sets the font size for the node.
         /// </summary>
         /// <param name="fontSize">The font size.</param>
@@ -201,41 +187,36 @@ namespace ReactNative.Views.Text
 
         private static MeasureOutput MeasureText(CSSNode node, float width, CSSMeasureMode widthMode, float height, CSSMeasureMode heightMode)
         {
-            // This is not a terribly efficient way of projecting the height of
-            // the text elements. It requires that we have access to the
-            // dispatcher in order to do measurement, which, for obvious
-            // reasons, can cause perceived performance issues as it will block
-            // the UI thread from handling other work.
-            //
-            // TODO: determine another way to measure text elements.
-            var task = DispatcherHelpers.CallOnDispatcher(() =>
+            // TODO: Measure text with DirectWrite or other API that does not
+            // require dispatcher access. Currently, we're instantiating a
+            // second CoreApplicationView (that is never activated) and using
+            // its Dispatcher thread to calculate layout.
+
+            var textNode = (ReactTextShadowNode)node;
+            textNode.ThemedContext.AssertOnLayoutQueueThread();
+
+            var textBlock = new RichTextBlock
             {
-                var textBlock = new RichTextBlock
-                {
-                    TextWrapping = TextWrapping.Wrap,
-                    TextAlignment = TextAlignment.DetectFromContent,
-                    TextTrimming = TextTrimming.CharacterEllipsis,
-                };
+                TextWrapping = TextWrapping.Wrap,
+                TextAlignment = TextAlignment.DetectFromContent,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+            };
 
-                var textNode = (ReactTextShadowNode)node;
-                textNode.UpdateTextBlockCore(textBlock, true);
+            textNode.UpdateTextBlockCore(textBlock, true);
 
-                var block = new Paragraph();
-                foreach (var child in textNode.Children)
-                {
-                    block.Inlines.Add(ReactInlineShadowNodeVisitor.Apply(child));
-                }
-                textBlock.Blocks.Add(block);
+            var block = new Paragraph();
+            foreach (var child in textNode.Children)
+            {
+                block.Inlines.Add(ReactInlineShadowNodeVisitor.Apply(child));
+            }
+            textBlock.Blocks.Add(block);
 
-                var normalizedWidth = CSSConstants.IsUndefined(width) ? double.PositiveInfinity : width;
-                var normalizedHeight = CSSConstants.IsUndefined(height) ? double.PositiveInfinity : height;
-                textBlock.Measure(new Size(normalizedWidth, normalizedHeight));
-                return new MeasureOutput(
-                    (float)textBlock.DesiredSize.Width,
-                    (float)textBlock.DesiredSize.Height);
-            });
-
-            return task.Result;
+            var normalizedWidth = CSSConstants.IsUndefined(width) ? double.PositiveInfinity : width;
+            var normalizedHeight = CSSConstants.IsUndefined(height) ? double.PositiveInfinity : height;
+            textBlock.Measure(new Size(normalizedWidth, normalizedHeight));
+            return new MeasureOutput(
+                (float)textBlock.DesiredSize.Width,
+                (float)textBlock.DesiredSize.Height);
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative/Views/Text/ReactTextViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactTextViewManager.cs
@@ -77,7 +77,7 @@ namespace ReactNative.Views.Text
         /// <returns>The shadow node instance.</returns>
         public override ReactTextShadowNode CreateShadowNodeInstance()
         {
-            return new ReactTextShadowNode(true);
+            return new ReactTextShadowNode();
         }
 
         /// <summary>


### PR DESCRIPTION
Text measurement was a bit of a performance bottleneck due to context switching from the native module thread to the dispatcher thread.

Eventually, we may want to implement text measurement that does not invole cloning the RichTextBox (e.g., using DWrite APIs or Win2D), but this is progress for now.

We create the layout thread from a static secondary CoreApplicationView with a Window that is never activated.