### PR TITLE
Update css-layout dependency

### DIFF
--- a/ReactWindows/ReactNative/Views/Text/ReactSpanShadowNode.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactSpanShadowNode.cs
@@ -127,5 +127,23 @@ namespace ReactNative.Views.Text
             inline.FontWeight = _fontWeight ?? FontWeights.Normal;
             inline.FontFamily = _fontFamily != null ? new FontFamily(_fontFamily) : FontFamily.XamlAutoFontFamily;
         }
+
+        /// <summary>
+        /// This method will be called by <see cref="UIManagerModule"/> once
+        /// per batch, before calculating layout. This will only be called for
+        /// nodes that are marked as updated with <see cref="MarkUpdated"/> or
+        /// require layout (i.e., marked with <see cref="dirty"/>).
+        /// </summary>
+        public override void OnBeforeLayout()
+        {
+            // Run flexbox on the children which are inline views.
+            foreach (var child in this.Children)
+            {
+                if (!(child is ReactRunShadowNode) && !(child is ReactSpanShadowNode))
+                {
+                    child.CalculateLayout();
+                }
+            }
+        }
     }
 }

--- a/ReactWindows/ReactNative/Views/Text/ReactTextShadowNode.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactTextShadowNode.cs
@@ -267,5 +267,23 @@ namespace ReactNative.Views.Text
                     0);
             }
         }
+
+        /// <summary>
+        /// This method will be called by <see cref="UIManagerModule"/> once
+        /// per batch, before calculating layout. This will only be called for
+        /// nodes that are marked as updated with <see cref="MarkUpdated"/> or
+        /// require layout (i.e., marked with <see cref="dirty"/>).
+        /// </summary>
+        public override void OnBeforeLayout()
+        {
+            // Run flexbox on the children which are inline views.
+            foreach (var child in this.Children)
+            {
+                if (!(child is ReactRunShadowNode) && !(child is ReactSpanShadowNode))
+                {
+                    child.CalculateLayout();
+                }
+            }
+        }
     }
 }

--- a/ReactWindows/ReactNative/project.json
+++ b/ReactWindows/ReactNative/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Facebook.CSSLayout": "2.0.0-pre",
+    "Facebook.CSSLayout": "2.0.1-pre",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0",
     "Newtonsoft.Json": "7.0.1",
     "Rx-Xaml": "2.2.5",


### PR DESCRIPTION
The updated version of css-layout includes significant
changes which make the layout engine conform closer to
the W3C spec. For details, see https://github.com/facebook/css-layout/pull/185

The inline view implementation had to be modified slightly
due to a change in the layout engine. In the updated layout
engine, nodes with a measure function are treated as leaves.
Consequently, nodes with a mesaure function (e.g. Text) do
not have their children laid out automatically.

To fix this, Text nodes now manually invoke the layout engine
on each of their inline views.