### PR TITLE
Fix inline images

### DIFF
--- a/Libraries/Image/Image.windows.js
+++ b/Libraries/Image/Image.windows.js
@@ -214,7 +214,7 @@ var Image = React.createClass({
             {this.props.children}
           </View>
         );
-      } else if (!this.context.isInAParentText) {
+      } else {
           return <RKImage {...nativeProps}/>;
       }
     }


### PR DESCRIPTION
In JS, the Image's render function was returning null
when it was used inside of a text element.