### PR TITLE
Fix destruction of inline views

### DIFF
--- a/ReactWindows/ReactNative/Views/Text/ReactTextViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactTextViewManager.cs
@@ -76,7 +76,16 @@ namespace ReactNative.Views.Text
         /// <returns>The child view.</returns>
         public override DependencyObject GetChildAt(RichTextBlock parent, int index)
         {
-            return parent.Blocks.OfType<Paragraph>().First().Inlines[index];
+            var child = parent.Blocks.OfType<Paragraph>().First().Inlines[index];
+            var childInlineContainer = child as InlineUIContainer;
+            if (childInlineContainer != null)
+            {
+                return childInlineContainer.Child;
+            }
+            else
+            {
+                return child;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Inline views get wrapped in an InlineUIContainer.
InlineUIContainers didn't have a tag so when its tag
was attempted to be found (e.g. during destruction), the
app would crash.

To fix this, the tag of the wrapped element is now copied onto
the InlineUIContainer.