### PR TITLE
Fix rendering of TextInput after programmatic focus

### DIFF
--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextBox.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextBox.cs
@@ -41,6 +41,7 @@ namespace ReactNative.Views.TextInput
 
         protected override void OnGotFocus(RoutedEventArgs e)
         {
+            base.OnGotFocus(e);
             if (ClearTextOnFocus)
             {
                 Text = "";


### PR DESCRIPTION
When programmatically giving a TextInput focus, it wasn't rendering
properly (e.g. the focus rect wasn't drawn, the cursor wasn't drawn or it
was drawn in the wrong spot, selected text wasn't highlighted).

It looks like ReactTextBox overrode OnGotFocus but forgot to give
TextBox's handler a chance to run.