### PR TITLE
Enable text wrapping for TextInput

### DIFF
--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
@@ -300,6 +300,7 @@ namespace ReactNative.Views.TextInput
         public void SetMultiline(ReactTextBox view, bool multiline)
         {
             view.AcceptsReturn = multiline;
+            view.TextWrapping = multiline ? TextWrapping.Wrap : TextWrapping.NoWrap;
         }
 
         /// <summary>


### PR DESCRIPTION
When TextInput's multiline prop is true, text that can't fit on the line
should wrap to the next line.