### PR TITLE
Add selectable prop to Text component

### DIFF
--- a/Libraries/Text/Text.windows.js
+++ b/Libraries/Text/Text.windows.js
@@ -31,6 +31,7 @@ const viewConfig = {
     numberOfLines: true,
     lineBreakMode: true,
     allowFontScaling: true,
+    selectable: true,
   }),
   uiViewClassName: 'RCTText',
 };
@@ -95,6 +96,13 @@ const Text = React.createClass({
      * This function is called on long press.
      */
     onLongPress: React.PropTypes.func,
+    /**
+     * Lets the user select text, to use the native copy and paste functionality.
+     *
+     * @platform android
+     * @platform windows
+     */
+    selectable: React.PropTypes.bool,
     /**
      * When true, no visual change is made when text is pressed down. By
      * default, a gray oval highlights the text on press down.

--- a/ReactWindows/ReactNative/Views/Text/ReactTextViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactTextViewManager.cs
@@ -40,6 +40,17 @@ namespace ReactNative.Views.Text
         }
 
         /// <summary>
+        /// Sets whether or not the text is selectable.
+        /// </summary>
+        /// <param name="view">The view.</param>
+        /// <param name="selectable">A flag indicating whether or not the text is selectable.</param>
+        [ReactProp("selectable")]
+        public void SetSelectable(RichTextBlock view, bool selectable)
+        {
+            view.IsTextSelectionEnabled = selectable;
+        }
+
+        /// <summary>
         /// Adds a child at the given index.
         /// </summary>
         /// <param name="parent">The parent view.</param>


### PR DESCRIPTION
This enables developers to configure whether or not Text is selectable.
This feature is already supported by React Native for Android.