### PR TITLE
Provide stub for View's accessible prop

### DIFF
--- a/ReactWindows/ReactNative/Views/View/ReactViewManager.cs
+++ b/ReactWindows/ReactNative/Views/View/ReactViewManager.cs
@@ -23,6 +23,21 @@ namespace ReactNative.Views.View
         }
 
         /// <summary>
+        /// Sets whether or not the view is an accessibility element.
+        /// </summary>
+        /// <param name="view">The view.</param>
+        /// <param name="accessible">A flag indicating whether or not the view is an accessibility element.</param>
+        [ReactProp("accessible")]
+        public void SetAccessible(Border view, bool accessible)
+        {
+            // TODO: #557 Provide implementation for View's accessible prop
+
+            // We need to have this stub for this prop so that Views which
+            // specify the accessible prop aren't considered to be layout-only.
+            // The proper implementation is still to be determined.
+        }
+
+        /// <summary>
         /// Set the pointer events handling mode for the view.
         /// </summary>
         /// <param name="view">The view.</param>


### PR DESCRIPTION
I don't know the proper implementation of this method but see below for why I'd like to add this stub. If you know the proper implementation, we can adjust the PR.

Because we didn't have any implementation for View's accessible prop, some
views were considered to be layout-only which weren't layout-only on iOS
and Android. The specific scenario I'm trying to fix is around touchables
(e.g. TouchableWithoutFeedback). I ran into a case where a touchable was
layout-only on Windows. When tapping it, React Native's JS code attempted
to measure the view. React Native was unable to return a result for the
measure request because the view that was being measured was layout-only.

React Native's JS sets accessible to true on touchables. According to the
React Native docs, "by default, all touchable elements are accessible."
(http://facebook.github.io/react-native/releases/0.30/docs/accessibility.html#accessible-ios-android)

By providing a stub implementation for the accessible prop, touchables
should never be layout-only on Windows thus fixing the measuring issue.

I opened issue #557 to track providing a proper implementation for the
accessible prop.