### PR TITLE
Fix crash in TouchHandler

### DIFF
--- a/ReactWindows/ReactNative/Touch/TouchHandler.cs
+++ b/ReactWindows/ReactNative/Touch/TouchHandler.cs
@@ -46,11 +46,11 @@ namespace ReactNative.Touch
             }
 
             var reactView = GetReactViewFromView(e.OriginalSource as UIElement);
-            var reactTag = reactView.GetReactCompoundView().GetReactTagAtPoint(reactView,
-                e.GetCurrentPoint(reactView).Position);
 
             if (reactView != null && _view.CapturePointer(e.Pointer))
             {
+                var reactTag = reactView.GetReactCompoundView().GetReactTagAtPoint(reactView,
+                    e.GetCurrentPoint(reactView).Position);
                 var pointer = new ReactPointer();
                 pointer.Target = reactTag;
                 pointer.PointerId = e.Pointer.PointerId;


### PR DESCRIPTION
An exception is raised when trying to call
reactView.GetReactCompoundView() when reactView is null. This change moves
this line into the branch where reactView cannot be null.