### PR TITLE
Proper escaption of .sln file in command line args

### DIFF
--- a/local-cli/runWindows/utils/msbuildtools.js
+++ b/local-cli/runWindows/utils/msbuildtools.js
@@ -47,7 +47,7 @@ class MSBuildTools {
       return;
     }
 
-    const cmd = `"${path.join(this.path, 'msbuild.exe')}" ` + [slnFile].concat(args).join(' ');
+    const cmd = `"${path.join(this.path, 'msbuild.exe')}" ` + ['"' + slnFile + '"'].concat(args).join(' ');
     const results = child_process.execSync(cmd).toString().split(EOL);
     results.forEach(result => console.log(chalk.white(result)));
   }


### PR DESCRIPTION
The call of msbuild.exe wasn't done with a properly escaped version of slnFile, so paths including whitespaces resulted in an error. This is fixed by adding quotation marks in front of and at the end of the slnFile.