### PR TITLE
fix(Timing): Fix comparator for scheduled timers

### DIFF
--- a/ReactWindows/ReactNative/Modules/Core/Timing.cs
+++ b/ReactWindows/ReactNative/Modules/Core/Timing.cs
@@ -27,7 +27,9 @@ namespace ReactNative.Modules.Core
         public Timing(ReactContext reactContext)
             : base(reactContext)
         {
-            _timers = new HeapBasedPriorityQueue<TimerData>(Comparer<TimerData>.Create((x, y) => (int)(x.TargetTime.Ticks - y.TargetTime.Ticks)));
+            _timers = new HeapBasedPriorityQueue<TimerData>(
+                Comparer<TimerData>.Create((x, y) => 
+                    x.TargetTime.CompareTo(y.TargetTime)));
         }
 
         /// <summary>
@@ -92,7 +94,7 @@ namespace ReactNative.Modules.Core
         /// Creates a timer with the given properties.
         /// </summary>
         /// <param name="callbackId">The timer identifier.</param>
-        /// <param name="duration">The duration.</param>
+        /// <param name="duration">The duration in milliseconds.</param>
         /// <param name="jsSchedulingTime">
         /// The Unix timestamp when the timer was created.
         /// </param>


### PR DESCRIPTION
The timing module comparison function was not behaving properly because of unchecked arithmetic. Switching the comparison to use the built-in IComparator behavior long values.  Also, adding a unit test to make sure this doesn't happen again.

Fixes #589