### PR TITLE
fix(DevSupport): Adds feature to load existing bundle from cache

### DIFF
--- a/ReactWindows/ReactNative/DevSupport/DevSupportManager.cs
+++ b/ReactWindows/ReactNative/DevSupport/DevSupportManager.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.Storage;
+using Windows.UI.Xaml;
 
 namespace ReactNative.DevSupport
 {
@@ -137,6 +138,23 @@ namespace ReactNative.DevSupport
             {
                 ExceptionDispatchInfo.Capture(exception).Throw();
             }
+        }
+
+        public async Task<bool> HasUpToDateBundleInCacheAsync()
+        {
+            if (_isDevSupportEnabled)
+            {
+                var lastUpdateTime = Windows.ApplicationModel.Package.Current.InstalledDate;
+                var localFolder = ApplicationData.Current.LocalFolder;
+                var bundleItem = await localFolder.TryGetItemAsync(JSBundleFileName);
+                if (bundleItem != null)
+                {
+                    var bundleProperties = await bundleItem.GetBasicPropertiesAsync();
+                    return bundleProperties.DateModified > lastUpdateTime;
+                }
+            }
+
+            return false;
         }
 
         public void ShowNewNativeError(string message, Exception exception)

--- a/ReactWindows/ReactNative/DevSupport/DisabledDevSupportManager.cs
+++ b/ReactWindows/ReactNative/DevSupport/DisabledDevSupportManager.cs
@@ -75,6 +75,11 @@ namespace ReactNative.DevSupport
         {
         }
 
+        public Task<bool> HasUpToDateBundleInCacheAsync()
+        {
+            return Task.FromResult(false);
+        }
+
         public void HideRedboxDialog()
         {
         }

--- a/ReactWindows/ReactNative/DevSupport/IDevSupportManager.cs
+++ b/ReactWindows/ReactNative/DevSupport/IDevSupportManager.cs
@@ -60,6 +60,12 @@ namespace ReactNative.DevSupport
         void HandleReloadJavaScript();
 
         /// <summary>
+        /// Checks if an up-to-date JavaScript bundle is ready.
+        /// </summary>
+        /// <returns>A task to await the result.</returns>
+        Task<bool> HasUpToDateBundleInCacheAsync();
+
+        /// <summary>
         /// Dismisses the red box exception dialog.
         /// </summary>
         void HideRedboxDialog();

--- a/ReactWindows/ReactNative/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative/ReactInstanceManager.cs
@@ -143,7 +143,7 @@ namespace ReactNative
         /// enforced to keep developers from accidentally creating their
         /// applications multiple times.
         /// </summary>
-        public void CreateReactContextInBackground()
+        public async void CreateReactContextInBackground()
         {
             if (_hasStartedCreatingInitialContext)
             {
@@ -154,7 +154,7 @@ namespace ReactNative
             }
 
             _hasStartedCreatingInitialContext = true;
-            RecreateReactContextInBackgroundInner();
+            await RecreateReactContextInBackgroundInnerAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace ReactNative
         /// if configuration has changed or the developer has requested the
         /// applicatio
         /// </summary>
-        public void RecreateReactContextInBackground()
+        public async void RecreateReactContextInBackground()
         {
             if (!_hasStartedCreatingInitialContext)
             {
@@ -171,7 +171,7 @@ namespace ReactNative
                     "create context background call.");
             }
 
-            RecreateReactContextInBackgroundInner();
+            await RecreateReactContextInBackgroundInnerAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -349,13 +349,20 @@ namespace ReactNative
             }
         }
 
-        private void RecreateReactContextInBackgroundInner()
+        private async Task RecreateReactContextInBackgroundInnerAsync()
         {
             DispatcherHelpers.AssertOnDispatcher();
 
             if (_useDeveloperSupport && _jsBundleFile == null && _jsMainModuleName != null)
             {
-                _devSupportManager.HandleReloadJavaScript();
+                if (await _devSupportManager.HasUpToDateBundleInCacheAsync())
+                {
+                    OnJavaScriptBundleLoadedFromServer();
+                }
+                else
+                {
+                    _devSupportManager.HandleReloadJavaScript();
+                }
             }
             else
             {


### PR DESCRIPTION
If the bundle file was created since the app has been last updated, use the existing bundle, otherwise, get a new bundle.

Fixes #604