### PR TITLE
chore(MSBuild): Clean up MSBuild warnings

### DIFF
--- a/ReactWindows/ReactNative/DevSupport/ProgressDialog.xaml.cs
+++ b/ReactWindows/ReactNative/DevSupport/ProgressDialog.xaml.cs
@@ -9,7 +9,7 @@ namespace ReactNative.DevSupport
     /// <remarks>
     /// This is used when awaiting the regeneration of the JavaScript bundle.
     /// </remarks>
-    public sealed partial class ProgressDialog : ContentDialog
+    sealed partial class ProgressDialog : ContentDialog
     {
         private readonly CancellationTokenSource _cancellationTokenSource;
 

--- a/ReactWindows/ReactNative/DevSupport/RedBoxDialog.xaml.cs
+++ b/ReactWindows/ReactNative/DevSupport/RedBoxDialog.xaml.cs
@@ -11,7 +11,7 @@ namespace ReactNative.DevSupport
     /// <summary>
     /// The content dialog for red box exception display.
     /// </summary>
-    public sealed partial class RedBoxDialog : ContentDialog, INotifyPropertyChanged
+    sealed partial class RedBoxDialog : ContentDialog, INotifyPropertyChanged
     {
         private readonly Action _onClick;
 

--- a/ReactWindows/ReactNative/Touch/JavaScriptResponderHandler.cs
+++ b/ReactWindows/ReactNative/Touch/JavaScriptResponderHandler.cs
@@ -8,10 +8,9 @@ namespace ReactNative.Touch
     /// This class coordinates JavaScript responder commands for the 
     /// <see cref="ReactNative.UIManager.UIManagerModule"/>. It should be set 
     /// as the <see cref="IOnInterceptTouchEventListener"/> for all newly 
-    /// created native views that implement 
-    /// <see cref="IReactInterceptingViewParent"/> and will dispatch touch
-    /// events to the JavaScript gesture recognizer when the JavaScript
-    /// responder is set to be enabled.
+    /// created native views that implement IReactInterceptingViewParent and 
+    /// will dispatch touch events to the JavaScript gesture recognizer when
+    /// the JavaScript responder is set to be enabled.
     /// </summary>
     public class JavaScriptResponderHandler : IOnInterceptTouchEventListener
     {


### PR DESCRIPTION
There's one remaining warning that currently can't be eliminated because it's sourced from generated code.
Warning	CS1591	Missing XML comment for publicly visible type or member 'XamlMetaDataProvider'	react-native-windows\ReactWindows\ReactNative\obj\x86\Debug\XamlTypeInfo.g.cs

Fixes #612