### PR TITLE
fix(ChakraBridge) - fixes AVE with disposal

### DIFF
--- a/ReactWindows/ChakraBridge/SerializedSourceContext.h
+++ b/ReactWindows/ChakraBridge/SerializedSourceContext.h
@@ -4,17 +4,20 @@
 
 struct SerializedSourceContext
 {
-	BYTE* byteCode;
-	const wchar_t* sourcePath;
-	wchar_t* scriptBuffer;
+    BYTE* byteCode;
+    const wchar_t* sourcePath;
+    wchar_t* scriptBuffer;
 
-	~SerializedSourceContext()
-	{
-		delete[] byteCode;
-		delete[] sourcePath;
-		if (scriptBuffer)
-		{
-			delete[] scriptBuffer;
-		}
-	}
+    ~SerializedSourceContext()
+    {
+        if (byteCode)
+        {
+            delete[] byteCode;
+        }
+
+        if (scriptBuffer)
+        {
+            delete[] scriptBuffer;
+        }
+    }
 };


### PR DESCRIPTION
Calling `delete[]` on the source script URI causes an AVE since it is not controlled by this scope.