### PR TITLE
fix(Image): Change default stretch setting on Image

### DIFF
--- a/ReactWindows/ReactNative/Views/Image/ReactImageManager.cs
+++ b/ReactWindows/ReactNative/Views/Image/ReactImageManager.cs
@@ -213,7 +213,10 @@ namespace ReactNative.Views.Image
         {
             return new Border
             {
-                Background = new ImageBrush(),
+                Background = new ImageBrush
+                {
+                    Stretch = Stretch.UniformToFill,
+                },
             };
         }
 


### PR DESCRIPTION
Previously, ImageBrush.Stretch defaulted to Stretch.Fill. A better choice for default behavior is Stretch.UniformToFill.

Fixes #638