### PR TITLE
fix(Clipboard) - removing unnecessary constructor

### DIFF
--- a/ReactWindows/ReactNative/Modules/Clipboard/ClipboardModule.cs
+++ b/ReactWindows/ReactNative/Modules/Clipboard/ClipboardModule.cs
@@ -11,7 +11,6 @@ namespace ReactNative.Modules.Clipboard
     /// </summary>
     class ClipboardModule : NativeModuleBase
     {
-
         /// <summary>
         /// The name of the native module.
         /// </summary>

--- a/ReactWindows/ReactNative/Modules/Clipboard/ClipboardModule.cs
+++ b/ReactWindows/ReactNative/Modules/Clipboard/ClipboardModule.cs
@@ -11,12 +11,6 @@ namespace ReactNative.Modules.Clipboard
     /// </summary>
     class ClipboardModule : NativeModuleBase
     {
-        /// <summary>
-        /// Instantiates the <see cref="ClipboardModule"/>.
-        /// </summary>
-        internal ClipboardModule()
-        {
-        }
 
         /// <summary>
         /// The name of the native module.


### PR DESCRIPTION
Constructor is marked internal which isn't necessary as the class itself is internal.