### PR TITLE
fix(TextInput): Enable user padding settings for TextInput.

### DIFF
--- a/ReactWindows/ReactNative/UIManager/CSSNodeExtensions.cs
+++ b/ReactWindows/ReactNative/UIManager/CSSNodeExtensions.cs
@@ -27,7 +27,7 @@ namespace ReactNative.UIManager
             return 0.0f;
         }
 
-        public static float GetPaddingSpace(this CSSNode node, CSSSpacingType spacingType)
+        public static float GetPaddingValue(this CSSNode node, CSSSpacingType spacingType)
         {
             var padding = node.GetPadding(spacingType);
             if (!CSSConstants.IsUndefined(padding))
@@ -55,13 +55,15 @@ namespace ReactNative.UIManager
                 return padding;
             }
 
-            padding = node.GetPadding(CSSSpacingType.All);
-            if (!CSSConstants.IsUndefined(padding))
-            {
-                return padding;
-            }
+            return node.GetPadding(CSSSpacingType.All);
+        }
 
-            return 0.0f;
+        public static float GetPaddingSpace(this CSSNode node, CSSSpacingType spacingType)
+        {
+            var padding = node.GetPaddingValue(spacingType);
+            return CSSConstants.IsUndefined(padding)
+                ? 0.0f
+                : padding;
         }
 
         public static float GetTopBorderWidth(this CSSNode node)

--- a/ReactWindows/ReactNative/UIManager/LayoutShadowNode.cs
+++ b/ReactWindows/ReactNative/UIManager/LayoutShadowNode.cs
@@ -167,7 +167,7 @@ namespace ReactNative.UIManager
             DefaultSingle = Undefined)]
         public void SetPaddings(int index, float padding)
         {
-            SetPadding(ViewProps.PaddingMarginSpacingTypes[index], padding);
+            SetPaddingCore(ViewProps.PaddingMarginSpacingTypes[index], padding);
         }
 
         /// <summary>
@@ -207,6 +207,19 @@ namespace ReactNative.UIManager
         public void SetShouldNotifyOnLayout(bool shouldNotifyOnLayout)
         {
             ShouldNotifyOnLayout = shouldNotifyOnLayout;
+        }
+
+        /// <summary>
+        /// Sets the padding of the shadow node.
+        /// </summary>
+        /// <param name="spacingType">The spacing type.</param>
+        /// <param name="padding">The padding value.</param>
+        /// <remarks>
+        /// Override this virtual method if the view has custom padding behavior.
+        /// </remarks>
+        protected virtual void SetPaddingCore(CSSSpacingType spacingType, float padding)
+        {
+            SetPadding(spacingType, padding);
         }
     }
 }


### PR DESCRIPTION
Padding settings were not accounted for because of the default paddings set for measurement.

Fixes #651