### PR TITLE
fix(ChakraBridge) - add back smarter serialization

### DIFF
--- a/ReactWindows/ChakraBridge/ChakraBridge.vcxproj
+++ b/ReactWindows/ChakraBridge/ChakraBridge.vcxproj
@@ -212,6 +212,7 @@
     <ClInclude Include="NativeJavaScriptExecutor.h" />
     <ClInclude Include="ChakraStringResult.h" />
     <ClInclude Include="pch.h" />
+    <ClInclude Include="SerializedSourceContext.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="asprintf.cpp" />

--- a/ReactWindows/ChakraBridge/ChakraBridge.vcxproj.filters
+++ b/ReactWindows/ChakraBridge/ChakraBridge.vcxproj.filters
@@ -20,5 +20,6 @@
     <ClInclude Include="NativeJavaScriptExecutor.h" />
     <ClInclude Include="asprintf.h" />
     <ClInclude Include="JsStringify.h" />
+    <ClInclude Include="SerializedSourceContext.h" />
   </ItemGroup>
 </Project>

--- a/ReactWindows/ChakraBridge/ChakraHost.cpp
+++ b/ReactWindows/ChakraBridge/ChakraHost.cpp
@@ -1,6 +1,7 @@
 ﻿#include "pch.h"
 #include "ChakraHost.h"
 #include "JsStringify.h"
+#include "SerializedSourceContext.h"
 
 void ThrowException(const wchar_t* szException)
 {
@@ -67,12 +68,38 @@ JsValueRef CALLBACK ConsoleError(JsValueRef callee, bool isConstructCall, JsValu
     return InvokeConsole(L"error", callee, isConstructCall, arguments, argumentCount, callbackState);
 }
 
-JsErrorCode ChakraHost::RunScriptFromFile(const wchar_t* szFileName, const wchar_t* szSourceUri, JsValueRef* result)
+JsErrorCode LoadByteCode(const wchar_t* szPath, BYTE** pData)
 {
-    JsErrorCode status = JsNoError;
     FILE *file;
+    *pData = nullptr;
 
-    if (_wfopen_s(&file, szFileName, L"rb"))
+    if (_wfopen_s(&file, szPath, L"rb"))
+    {
+        return JsErrorInvalidArgument;
+    }
+
+    unsigned int current = ftell(file);
+    fseek(file, 0, SEEK_END);
+    unsigned int end = ftell(file);
+    fseek(file, current, SEEK_SET);
+    unsigned int lengthBytes = end - current;
+
+    *pData = new BYTE[lengthBytes];
+    fread(*pData, sizeof(BYTE), lengthBytes, file);
+    if (fclose(file))
+    {
+        return JsErrorFatal;
+    }
+
+    return JsNoError;
+}
+
+JsErrorCode LoadFileContents(const wchar_t* szPath, wchar_t** pszData)
+{
+    FILE *file;
+    *pszData = nullptr;
+
+    if (_wfopen_s(&file, szPath, L"rb"))
     {
         return JsErrorInvalidArgument;
     }
@@ -89,37 +116,105 @@ JsErrorCode ChakraHost::RunScriptFromFile(const wchar_t* szFileName, const wchar
         return JsErrorFatal;
     }
 
-    fread((void *)rawBytes, sizeof(char), lengthBytes, file);
+    fread(rawBytes, sizeof(char), lengthBytes, file);
     if (fclose(file))
     {
         return JsErrorFatal;
     }
 
-    wchar_t *contents = (wchar_t *)calloc(lengthBytes + 1, sizeof(wchar_t));
-    if (contents == nullptr)
+    *pszData = (wchar_t *)calloc(lengthBytes + 1, sizeof(wchar_t));
+    if (*pszData == nullptr)
     {
         free(rawBytes);
         return JsErrorFatal;
     }
 
-    if (MultiByteToWideChar(CP_UTF8, 0, rawBytes, lengthBytes + 1, contents, lengthBytes + 1) == 0)
+    if (MultiByteToWideChar(CP_UTF8, 0, rawBytes, lengthBytes + 1, *pszData, lengthBytes + 1) == 0)
     {
+        free(*pszData);
         free(rawBytes);
-        free(contents);
         return JsErrorFatal;
     }
 
-    status = RunScript(contents, szSourceUri, result);
+    return JsNoError;
+}
 
-    free(rawBytes);
-    free(contents);
+bool CompareLastWrite(const wchar_t* szPath1, const wchar_t* szPath2)
+{
+    HANDLE hPath1, hPath2;
+    FILETIME ftPath1Create, ftPath1Access, ftPath1Write;
+    FILETIME ftPath2Create, ftPath2Access, ftPath2Write;
 
+    hPath1 = CreateFile2(szPath1, GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING, nullptr);
+    if (hPath1 == INVALID_HANDLE_VALUE && GetLastError() == ERROR_FILE_NOT_FOUND) {
+        return false;
+    }
+
+    hPath2 = CreateFile2(szPath2, GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING, nullptr);
+
+    GetFileTime(hPath1, &ftPath1Create, &ftPath1Access, &ftPath1Write);
+    GetFileTime(hPath2, &ftPath2Create, &ftPath2Access, &ftPath2Write);
+
+    CloseHandle(hPath1);
+    CloseHandle(hPath2);
+
+    return CompareFileTime(&ftPath1Write, &ftPath2Write) == 1;
+}
+
+bool CALLBACK LoadSourceCallback(JsSourceContext sourceContext, const wchar_t** scriptBuffer)
+{
+    SerializedSourceContext* context = (SerializedSourceContext*)sourceContext;
+    *scriptBuffer = context->scriptBuffer;
+    return true;
+}
+
+void CALLBACK UnloadSourceCallback(JsSourceContext sourceContext)
+{
+    SerializedSourceContext* context = (SerializedSourceContext*)sourceContext;
+    delete context;
+}
+
+JsErrorCode ChakraHost::RunSerializedScript(const wchar_t* szPath, const wchar_t* szSerializedPath, const wchar_t* szSourceUri, JsValueRef* result)
+{
+    JsErrorCode status = JsNoError;
+    ULONG bufferSize = 0L;
+    BYTE* buffer = nullptr;
+    wchar_t* szScriptBuffer = nullptr;
+    IfFailRet(LoadFileContents(szPath, &szScriptBuffer));
+
+    if (!CompareLastWrite(szSerializedPath, szPath))
+    {
+        IfFailRet(JsSerializeScript(szScriptBuffer, buffer, &bufferSize));
+        buffer = new BYTE[bufferSize];
+        IfFailRet(JsSerializeScript(szScriptBuffer, buffer, &bufferSize));
+
+        FILE* file;
+        _wfopen_s(&file, szSerializedPath, L"wb");
+        fwrite(buffer, sizeof(BYTE), bufferSize, file);
+        fclose(file);
+    }
+    else
+    {
+        IfFailRet(LoadByteCode(szSerializedPath, &buffer));
+    }
+
+    SerializedSourceContext* context = new SerializedSourceContext();
+    context->byteBuffer = buffer;
+    context->scriptBuffer = szScriptBuffer;
+
+    IfFailRet(JsRunSerializedScriptWithCallback(&LoadSourceCallback, &UnloadSourceCallback, buffer, (JsSourceContext)context, szSourceUri, result));
     return status;
 }
 
-JsErrorCode ChakraHost::RunScript(const wchar_t* szScript, const wchar_t* szSourceUri, JsValueRef* result)
+JsErrorCode ChakraHost::RunScript(const wchar_t* szFileName, const wchar_t* szSourceUri, JsValueRef* result)
 {
-    return JsRunScript(szScript, currentSourceContext++, szSourceUri, result);
+    wchar_t* contents = nullptr;
+    IfFailRet(LoadFileContents(szFileName, &contents));
+
+    JsErrorCode status = JsRunScript(contents, currentSourceContext++, szSourceUri, result);
+    free(contents);
+
+    return status;
 }
 
 JsErrorCode ChakraHost::JsonStringify(JsValueRef argument, JsValueRef* result)

--- a/ReactWindows/ChakraBridge/ChakraHost.h
+++ b/ReactWindows/ChakraBridge/ChakraHost.h
@@ -2,6 +2,7 @@
 
 #include "pch.h"
 #include <jsrt.h>
+
 bool CompareLastWrite(const wchar_t* szPath1, const wchar_t* szPath2);
 JsErrorCode LoadByteCode(const wchar_t* szPath, BYTE** pData, HANDLE* hFile, HANDLE* hMap);
 JsErrorCode LoadFileContents(const wchar_t* szPath, wchar_t** pszData);
@@ -28,16 +29,16 @@ public:
 	/// </returns>
 	JsErrorCode Destroy();
 
-	/// <summary>
-	/// Runs the script from the file location with the source URI and returns the <see cref="JsValueRef" /> result.
-	///</summary>
-	/// <param name="szPath">The location of the script to run.</param>
-	/// <param name="szSourceUri">The source URI of the script.</param>
-	/// <param name="result">[Out] The result from running the script.</param>
-	/// <returns>
-	/// JsNoError is no error, else a JsErrorCode with the appropriate error.
-	/// </returns>
-	JsErrorCode RunScript(const wchar_t* szPath, const wchar_t* szSourceUri, JsValueRef* result);
+    /// <summary>
+    /// Runs the script from the file location with the source URI and returns the <see cref="JsValueRef" /> result.
+    ///</summary>
+    /// <param name="szPath">The location of the script to run.</param>
+    /// <param name="szSourceUri">The source URI of the script.</param>
+    /// <param name="result">[Out] The result from running the script.</param>
+    /// <returns>
+    /// JsNoError is no error, else a JsErrorCode with the appropriate error.
+    /// </returns>
+    JsErrorCode RunScript(const wchar_t* szPath, const wchar_t* szSourceUri, JsValueRef* result);
 
     /// <summary>
     /// Runs the serialized script from the serialized file location with source file path, source URI and returns the <see cref="JsValueRef" /> result.

--- a/ReactWindows/ChakraBridge/ChakraHost.h
+++ b/ReactWindows/ChakraBridge/ChakraHost.h
@@ -2,6 +2,9 @@
 
 #include "pch.h"
 #include <jsrt.h>
+bool CompareLastWrite(const wchar_t* szPath1, const wchar_t* szPath2);
+JsErrorCode LoadByteCode(const wchar_t* szPath, BYTE** pData);
+JsErrorCode LoadFileContents(const wchar_t* szPath, wchar_t** pszData);
 
 /// <summary>
 /// This class wraps the main functionality dealing with the JSRT.
@@ -26,17 +29,6 @@ public:
 	JsErrorCode Destroy();
 
 	/// <summary>
-	/// Runs the given script with the source URI and returns the <see cref="JsValueRef" /> result.
-	///</summary>
-	/// <param name="szScript">The script to run.</param>
-	/// <param name="szSourceUri">The source URI of the script.</param>
-	/// <param name="result">[Out] The result from running the script.</param>
-	/// <returns>
-	/// JsNoError is no error, else a JsErrorCode with the appropriate error.
-	/// </returns>
-	JsErrorCode RunScript(const wchar_t* szScript, const wchar_t* szSourceUri, JsValueRef* result);
-
-	/// <summary>
 	/// Runs the script from the file location with the source URI and returns the <see cref="JsValueRef" /> result.
 	///</summary>
 	/// <param name="szPath">The location of the script to run.</param>
@@ -45,7 +37,19 @@ public:
 	/// <returns>
 	/// JsNoError is no error, else a JsErrorCode with the appropriate error.
 	/// </returns>
-	JsErrorCode RunScriptFromFile(const wchar_t* szPath, const wchar_t* szSourceUri, JsValueRef* result);
+	JsErrorCode RunScript(const wchar_t* szPath, const wchar_t* szSourceUri, JsValueRef* result);
+
+    /// <summary>
+    /// Runs the serialized script from the serialized file location with source file path, source URI and returns the <see cref="JsValueRef" /> result.
+    /// </summary>
+    /// <param name="szPath">The location of the script to run.</param>
+    /// <param name="szSerializedPath">The location of the serialized script to run.</param>
+    /// <param name="szSourceUri">The source URI of the script.</param>
+    /// <param name="result">[Out] The result from running the script.</param>
+    /// <returns>
+    /// JsNoError is no error, else a JsErrorCode with the appropriate error.
+    /// </returns>
+    JsErrorCode RunSerializedScript(const wchar_t* szPath, const wchar_t* szSerializedPath, const wchar_t* szSourceUri, JsValueRef* result);
 
 	/// <summary>
 	/// Calls JSON stringify on the given <see cref="JsValueRef" /> and returns the <see cref="JsValueRef" /> result.

--- a/ReactWindows/ChakraBridge/ChakraHost.h
+++ b/ReactWindows/ChakraBridge/ChakraHost.h
@@ -3,7 +3,7 @@
 #include "pch.h"
 #include <jsrt.h>
 bool CompareLastWrite(const wchar_t* szPath1, const wchar_t* szPath2);
-JsErrorCode LoadByteCode(const wchar_t* szPath, BYTE** pData);
+JsErrorCode LoadByteCode(const wchar_t* szPath, BYTE** pData, HANDLE* hFile, HANDLE* hMap);
 JsErrorCode LoadFileContents(const wchar_t* szPath, wchar_t** pszData);
 
 /// <summary>

--- a/ReactWindows/ChakraBridge/NativeJavaScriptExecutor.cpp
+++ b/ReactWindows/ChakraBridge/NativeJavaScriptExecutor.cpp
@@ -1,6 +1,8 @@
 #include "pch.h"
 #include "NativeJavaScriptExecutor.h"
 
+const wchar_t* BATCH_BRIDGE = L"__fbBatchedBridge";
+
 using namespace ChakraBridge;
 
 int NativeJavaScriptExecutor::InitializeHost()
@@ -48,17 +50,17 @@ int NativeJavaScriptExecutor::RunScript(String^ source, String^ sourceUri)
     return JsNoError;
 }
 
-int NativeJavaScriptExecutor::RunScriptFromFile(String^ sourceFilePath, String^ sourceUri)
+int NativeJavaScriptExecutor::RunSerializedScript(String^ source, String^ serialized, String^ sourceUri)
 {
     JsValueRef result;
-    IfFailRet(this->host.RunScriptFromFile(sourceFilePath->Data(), sourceUri->Data(), &result));
+    IfFailRet(this->host.RunSerializedScript(source->Data(), serialized->Data(), sourceUri->Data(), &result));
     return JsNoError;
 }
 
 ChakraStringResult NativeJavaScriptExecutor::CallFunctionAndReturnFlushedQueue(String^ moduleName, String^ methodName, String^ args)
 {
     JsPropertyIdRef fbBridgeId;
-    IfFailRetNullPtr(JsGetPropertyIdFromName(L"__fbBatchedBridge", &fbBridgeId));
+    IfFailRetNullPtr(JsGetPropertyIdFromName(BATCH_BRIDGE, &fbBridgeId));
 
     JsValueRef fbBridgeObj;
     IfFailRetNullPtr(JsGetProperty(host.globalObject, fbBridgeId, &fbBridgeObj));
@@ -97,7 +99,7 @@ ChakraStringResult NativeJavaScriptExecutor::CallFunctionAndReturnFlushedQueue(S
 ChakraStringResult NativeJavaScriptExecutor::InvokeCallbackAndReturnFlushedQueue(int callbackId, String^ args)
 {
     JsPropertyIdRef fbBridgeId;
-    IfFailRetNullPtr(JsGetPropertyIdFromName(L"__fbBatchedBridge", &fbBridgeId));
+    IfFailRetNullPtr(JsGetPropertyIdFromName(BATCH_BRIDGE, &fbBridgeId));
 
     JsValueRef fbBridgeObj;
     IfFailRetNullPtr(JsGetProperty(host.globalObject, fbBridgeId, &fbBridgeObj));
@@ -135,7 +137,7 @@ ChakraStringResult NativeJavaScriptExecutor::InvokeCallbackAndReturnFlushedQueue
 ChakraStringResult NativeJavaScriptExecutor::FlushedQueue()
 {
     JsPropertyIdRef fbBridgeId;
-    IfFailRetNullPtr(JsGetPropertyIdFromName(L"__fbBatchedBridge", &fbBridgeId));
+    IfFailRetNullPtr(JsGetPropertyIdFromName(BATCH_BRIDGE, &fbBridgeId));
 
     JsValueRef fbBridgeObj;
     IfFailRetNullPtr(JsGetProperty(host.globalObject, fbBridgeId, &fbBridgeObj));

--- a/ReactWindows/ChakraBridge/NativeJavaScriptExecutor.h
+++ b/ReactWindows/ChakraBridge/NativeJavaScriptExecutor.h
@@ -59,15 +59,16 @@ public:
 	/// </returns>
     int RunScript(String^ source, String^ sourceUri);
 
-	/// <summary>
-	/// Runs the script from the file location and source URI and returns the result.
-	/// </summary>
-	/// <param name="sourceFilePath">The file path which contains the source to run.</param>
-	/// <param name="sourceUri">The source URI of the script to run.</param>
-	/// <returns>
-	/// A compount result with the JSON stringified value and an error code if any occurred.
-	/// </returns>
-    int RunScriptFromFile(String^ sourceFilePath, String^ sourceUri);
+    /// <summary>
+    /// Runs the given serialized script with the source URI and returns the result.
+    /// </summary>
+    /// <param name="source">The source of the script to run.</param>
+    /// <param name="serialized">The serialized script to run.</param>
+    /// <param name="sourceUri">The source URI of the script to run.</param>
+    /// <returns>
+    /// A compount result with the JSON stringified value and an error code if any occurred.
+    /// </returns>
+    int RunSerializedScript(String^ source, String^ serialized, String^ sourceUri);
 
 	/// <summary>
 	/// Calls the underlying function with the given module and method name and JSON stringified arguments.

--- a/ReactWindows/ChakraBridge/SerializedSourceContext.h
+++ b/ReactWindows/ChakraBridge/SerializedSourceContext.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <jsrt.h>
+
+struct SerializedSourceContext
+{
+    BYTE* byteBuffer;
+    wchar_t* scriptBuffer;
+
+    ~SerializedSourceContext()
+    {
+        if (byteBuffer != nullptr)
+        {
+            delete[] byteBuffer;
+        }
+        if (scriptBuffer != nullptr)
+        {
+            delete[] scriptBuffer;
+        }
+    }
+};

--- a/ReactWindows/ChakraBridge/SerializedSourceContext.h
+++ b/ReactWindows/ChakraBridge/SerializedSourceContext.h
@@ -4,18 +4,23 @@
 
 struct SerializedSourceContext
 {
+    HANDLE fileHandle;
+    HANDLE mapHandle;
     BYTE* byteBuffer;
     wchar_t* scriptBuffer;
 
     ~SerializedSourceContext()
     {
-        if (byteBuffer != nullptr)
+        if (fileHandle != NULL)
+        {
+            UnmapViewOfFile(byteBuffer);
+            CloseHandle(mapHandle);
+            CloseHandle(fileHandle);
+        }
+        else
         {
             delete[] byteBuffer;
         }
-        if (scriptBuffer != nullptr)
-        {
-            delete[] scriptBuffer;
-        }
+        delete[] scriptBuffer;
     }
 };


### PR DESCRIPTION
Adds back serialization to the ChakraHost with smarter file loading for serialized scripts.

For data, this assumes the binary file already exists:

```txt
** Serialized Native Code **
App Report: private: 49373184, peak private: 49573888, total commit: 128131072
Process Report: private working set: 27676672, total working set: 68775936
Elapsed ms: 1006
App Report: private: 68173824, peak private: 68173824, total commit: 146931712
Process Report: private working set: 43331584, total working set: 84590592

** Unserialized Native Code **
App Report: private: 57757696, peak private: 57757696, total commit: 136007680
Process Report: private working set: 29859840, total working set: 70004736
Elapsed ms: 1346
App Report: private: 71086080, peak private: 78913536, total commit: 149336064
Process Report: private working set: 44154880, total working set: 84381696

** C# P/Invoke **
App Report: private: 54976512, peak private: 54980608, total commit: 133230592
Process Report: private working set: 29085696, total working set: 67604480
Elapsed ms: 3333
App Report: private: 76910592, peak private: 76959744, total commit: 155160576
Process Report: private working set: 48705536, total working set: 87470080
```