### PR TITLE
feat(TextInput) - add border and background color to shadow node

### DIFF
--- a/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
@@ -14,8 +14,14 @@ using Windows.UI.Xaml.Media;
 
 namespace ReactNative.Views.TextInput
 {
+    /// <summary>
+    /// View manager for <see cref="PasswordBox"/>.
+    /// </summary>
     class ReactPasswordBoxManager : BaseViewManager<PasswordBox, ReactPasswordBoxShadowNode>
     {
+        /// <summary>
+        /// The name of the view manager.
+        /// </summary>
         public override string Name
         {
             get
@@ -191,7 +197,20 @@ namespace ReactNative.Views.TextInput
         }
 
         /// <summary>
-        /// Sets the background color for the <see cref="PasswordBox"/>.
+        /// Sets the border color for the <see cref="ReactTextBox"/>.
+        /// </summary>
+        /// <param name="view">The view instance</param>
+        /// <param name="color">The masked color value.</param>
+        [ReactProp("borderColor", CustomType = "Color")]
+        public void SetBorderColor(PasswordBox view, uint? color)
+        {
+            view.BorderBrush = color.HasValue
+                ? new SolidColorBrush(ColorHelpers.Parse(color.Value))
+                : new SolidColorBrush(ReactTextInputManager.DefaultTextBoxBorder);
+        }
+
+        /// <summary>
+        /// Sets the background color for the <see cref="ReactTextBox"/>.
         /// </summary>
         /// <param name="view">The view instance.</param>
         /// <param name="color">The masked color value.</param>
@@ -351,7 +370,7 @@ namespace ReactNative.Views.TextInput
         }
 
         /// <summary>
-        /// Called when view is detached from view hierarchy and allows for 
+        /// Called when view is detached from view hierarchy and allows for
         /// additional cleanup by the <see cref="ReactTextInputManager"/>.
         /// subclass. Unregister all event handlers for the <see cref="PasswordBox"/>.
         /// </summary>

--- a/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxShadowNode.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxShadowNode.cs
@@ -31,9 +31,6 @@ namespace ReactNative.Views.TextInput
         private FontStyle? _fontStyle;
         private FontWeight? _fontWeight;
 
-        private Color? _background;
-        private Color? _borderColor;
-
         private string _fontFamily;
         private string _text;
 
@@ -48,42 +45,6 @@ namespace ReactNative.Views.TextInput
             SetPadding(CSSSpacingType.Right, computedPadding[2]);
             SetPadding(CSSSpacingType.Bottom, computedPadding[3]);
             MeasureFunction = MeasureTextInput;
-        }
-
-        /// <summary>
-        /// Sets the background color for the <see cref="ReactTextBox"/>.
-        /// </summary>
-        /// <param name="color">The masked color value.</param>
-        [ReactProp(ViewProps.BackgroundColor, CustomType = "Color")]
-        public void SetBackgroundColor(uint? color)
-        {
-            if (color.HasValue)
-            {
-                var background = ColorHelpers.Parse(color.Value);
-                if (background != _background)
-                {
-                    _background = background;
-                    MarkUpdated();
-                }
-            }
-        }
-
-        /// <summary>
-        /// Sets the border color for the <see cref="ReactTextBox"/>.
-        /// </summary>
-        /// <param name="color">The masked color value.</param>
-        [ReactProp("borderColor", CustomType = "Color")]
-        public void SetBorderColor(uint? color)
-        {
-            if (color.HasValue)
-            {
-                var borderColor = ColorHelpers.Parse(color.Value);
-                if (borderColor != _borderColor)
-                {
-                    _borderColor = borderColor;
-                    MarkUpdated();
-                }
-            }
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxShadowNode.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxShadowNode.cs
@@ -6,6 +6,7 @@ using ReactNative.UIManager.Annotations;
 using ReactNative.Views.Text;
 using System;
 using Windows.Foundation;
+using Windows.UI;
 using Windows.UI.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -15,7 +16,7 @@ using Windows.UI.Xaml.Media;
 namespace ReactNative.Views.TextInput
 {
     /// <summary>
-    /// This extension of <see cref="LayoutShadowNode"/> is responsible for 
+    /// This extension of <see cref="LayoutShadowNode"/> is responsible for
     /// measuring the layout for Native <see cref="PasswordBox"/>.
     /// </summary>
     public class ReactPasswordBoxShadowNode : LayoutShadowNode
@@ -32,6 +33,9 @@ namespace ReactNative.Views.TextInput
         private FontStyle? _fontStyle;
         private FontWeight? _fontWeight;
 
+        private Color? _background;
+        private Color? _borderColor;
+
         private string _fontFamily;
         private string _text;
 
@@ -46,6 +50,42 @@ namespace ReactNative.Views.TextInput
             SetPadding(CSSSpacingType.Right, computedPadding[2]);
             SetPadding(CSSSpacingType.Bottom, computedPadding[3]);
             MeasureFunction = MeasureTextInput;
+        }
+
+        /// <summary>
+        /// Sets the background color for the <see cref="ReactTextBox"/>.
+        /// </summary>
+        /// <param name="color">The masked color value.</param>
+        [ReactProp(ViewProps.BackgroundColor, CustomType = "Color")]
+        public void SetBackgroundColor(uint? color)
+        {
+            if (color.HasValue)
+            {
+                var background = ColorHelpers.Parse(color.Value);
+                if (background != _background)
+                {
+                    _background = background;
+                    MarkUpdated();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Sets the border color for the <see cref="ReactTextBox"/>.
+        /// </summary>
+        /// <param name="color">The masked color value.</param>
+        [ReactProp("borderColor", CustomType = "Color")]
+        public void SetBorderColor(uint? color)
+        {
+            if (color.HasValue)
+            {
+                var borderColor = ColorHelpers.Parse(color.Value);
+                if (borderColor != _borderColor)
+                {
+                    _borderColor = borderColor;
+                    MarkUpdated();
+                }
+            }
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
@@ -5,6 +5,7 @@ using ReactNative.UIManager.Annotations;
 using ReactNative.Views.Text;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Windows.System;
 using Windows.UI;
 using Windows.UI.Text;
@@ -24,6 +25,15 @@ namespace ReactNative.Views.TextInput
         internal const int BlurTextInput = 2;
 
         private bool _onSelectionChange;
+
+        private static readonly Color DefaultTextBoxBorder =
+            new Color
+            {
+                A = byte.Parse("FF", NumberStyles.AllowHexSpecifier),
+                R = byte.Parse("7A", NumberStyles.AllowHexSpecifier),
+                G = byte.Parse("7A", NumberStyles.AllowHexSpecifier),
+                B = byte.Parse("7A", NumberStyles.AllowHexSpecifier)
+            };
 
         /// <summary>
         /// The name of the view manager.
@@ -210,6 +220,19 @@ namespace ReactNative.Views.TextInput
         public void SetPlaceholder(ReactTextBox view, string placeholder)
         {
             view.PlaceholderText = placeholder;
+        }
+
+        /// <summary>
+        /// Sets the border color for the <see cref="ReactTextBox"/>.
+        /// </summary>
+        /// <param name="view">The view instance</param>
+        /// <param name="color">The masked color value.</param>
+        [ReactProp("borderColor", CustomType = "Color")]
+        public void SetBorderColor(ReactTextBox view, uint? color)
+        {
+            view.BorderBrush = color.HasValue
+                ? new SolidColorBrush(ColorHelpers.Parse(color.Value))
+                : new SolidColorBrush(DefaultTextBoxBorder);
         }
 
         /// <summary>
@@ -441,7 +464,7 @@ namespace ReactNative.Views.TextInput
         }
 
         /// <summary>
-        /// Called when view is detached from view hierarchy and allows for 
+        /// Called when view is detached from view hierarchy and allows for
         /// additional cleanup by the <see cref="ReactTextInputManager"/>.
         /// subclass. Unregister all event handlers for the <see cref="ReactTextBox"/>.
         /// </summary>

--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
@@ -26,14 +26,7 @@ namespace ReactNative.Views.TextInput
 
         private bool _onSelectionChange;
 
-        internal static readonly Color DefaultTextBoxBorder =
-            new Color
-            {
-                A = byte.Parse("FF", NumberStyles.AllowHexSpecifier),
-                R = byte.Parse("7A", NumberStyles.AllowHexSpecifier),
-                G = byte.Parse("7A", NumberStyles.AllowHexSpecifier),
-                B = byte.Parse("7A", NumberStyles.AllowHexSpecifier)
-            };
+        internal static readonly Color DefaultTextBoxBorder = Color.FromArgb(255, 122, 122, 122);
 
         /// <summary>
         /// The name of the view manager.

--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
@@ -26,7 +26,7 @@ namespace ReactNative.Views.TextInput
 
         private bool _onSelectionChange;
 
-        private static readonly Color DefaultTextBoxBorder =
+        internal static readonly Color DefaultTextBoxBorder =
             new Color
             {
                 A = byte.Parse("FF", NumberStyles.AllowHexSpecifier),

--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputShadowNode.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputShadowNode.cs
@@ -86,7 +86,7 @@ namespace ReactNative.Views.TextInput
         /// </summary>
         /// <param name="color">The masked color value.</param>
         [ReactProp("borderColor", CustomType = "Color")]
-        public void SetBorderCOlor(uint? color)
+        public void SetBorderColor(uint? color)
         {
             if (color.HasValue)
             {

--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputShadowNode.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputShadowNode.cs
@@ -5,6 +5,7 @@ using ReactNative.UIManager.Annotations;
 using ReactNative.Views.Text;
 using System;
 using Windows.Foundation;
+using Windows.UI;
 using Windows.UI.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -14,7 +15,7 @@ using Windows.UI.Xaml.Media;
 namespace ReactNative.Views.TextInput
 {
     /// <summary>
-    /// This extension of <see cref="LayoutShadowNode"/> is responsible for 
+    /// This extension of <see cref="LayoutShadowNode"/> is responsible for
     /// measuring the layout for Native <see cref="TextBox"/>.
     /// </summary>
     public class ReactTextInputShadowNode : LayoutShadowNode
@@ -42,6 +43,9 @@ namespace ReactNative.Views.TextInput
         private FontWeight? _fontWeight;
         private TextAlignment _textAlignment = TextAlignment.DetectFromContent;
 
+        private Color? _background;
+        private Color? _borderColor;
+
         private string _fontFamily;
         private string _text;
 
@@ -57,6 +61,42 @@ namespace ReactNative.Views.TextInput
             SetPadding(CSSSpacingType.Right, s_defaultPaddings[2]);
             SetPadding(CSSSpacingType.Bottom, s_defaultPaddings[3]);
             MeasureFunction = MeasureTextInput;
+        }
+
+        /// <summary>
+        /// Sets the background color for the <see cref="ReactTextBox"/>.
+        /// </summary>
+        /// <param name="color">The masked color value.</param>
+        [ReactProp(ViewProps.BackgroundColor, CustomType = "Color")]
+        public void SetBackgroundColor(uint? color)
+        {
+            if (color.HasValue)
+            {
+                var background = ColorHelpers.Parse(color.Value);
+                if (background != _background)
+                {
+                    _background = background;
+                    MarkUpdated();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Sets the border color for the <see cref="ReactTextBox"/>.
+        /// </summary>
+        /// <param name="color">The masked color value.</param>
+        [ReactProp("borderColor", CustomType = "Color")]
+        public void SetBorderCOlor(uint? color)
+        {
+            if (color.HasValue)
+            {
+                var borderColor = ColorHelpers.Parse(color.Value);
+                if (borderColor != _borderColor)
+                {
+                    _borderColor = borderColor;
+                    MarkUpdated();
+                }
+            }
         }
 
         /// <summary>
@@ -274,7 +314,7 @@ namespace ReactNative.Views.TextInput
             var originalPadding = GetPadding(spacingType);
             if (!isUserPadding)
             {
-                SetPadding(spacingType, CSSConstants.Undefined);        
+                SetPadding(spacingType, CSSConstants.Undefined);
             }
 
             var result = this.GetPaddingValue(spacingType);

--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputShadowNode.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputShadowNode.cs
@@ -6,7 +6,6 @@ using ReactNative.UIManager.Annotations;
 using ReactNative.Views.Text;
 using System;
 using Windows.Foundation;
-using Windows.UI;
 using Windows.UI.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -44,9 +43,6 @@ namespace ReactNative.Views.TextInput
         private FontWeight? _fontWeight;
         private TextAlignment _textAlignment = TextAlignment.DetectFromContent;
 
-        private Color? _background;
-        private Color? _borderColor;
-
         private string _fontFamily;
         private string _text;
 
@@ -62,42 +58,6 @@ namespace ReactNative.Views.TextInput
             SetPadding(CSSSpacingType.Right, s_defaultPaddings[2]);
             SetPadding(CSSSpacingType.Bottom, s_defaultPaddings[3]);
             MeasureFunction = MeasureTextInput;
-        }
-
-        /// <summary>
-        /// Sets the background color for the <see cref="ReactTextBox"/>.
-        /// </summary>
-        /// <param name="color">The masked color value.</param>
-        [ReactProp(ViewProps.BackgroundColor, CustomType = "Color")]
-        public void SetBackgroundColor(uint? color)
-        {
-            if (color.HasValue)
-            {
-                var background = ColorHelpers.Parse(color.Value);
-                if (background != _background)
-                {
-                    _background = background;
-                    MarkUpdated();
-                }
-            }
-        }
-
-        /// <summary>
-        /// Sets the border color for the <see cref="ReactTextBox"/>.
-        /// </summary>
-        /// <param name="color">The masked color value.</param>
-        [ReactProp("borderColor", CustomType = "Color")]
-        public void SetBorderColor(uint? color)
-        {
-            if (color.HasValue)
-            {
-                var borderColor = ColorHelpers.Parse(color.Value);
-                if (borderColor != _borderColor)
-                {
-                    _borderColor = borderColor;
-                    MarkUpdated();
-                }
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
As per #653, adding `borderColor` and `backgroundColor` to the shadow node. Note that `borderRadius` is not supported on the `TextBox` so we cannot support that for UWP.