### PR TITLE
fix(Slider): Change default behaviors for Slider

### DIFF
--- a/ReactWindows/ReactNative/Shell/MainReactPackage.cs
+++ b/ReactWindows/ReactNative/Shell/MainReactPackage.cs
@@ -121,6 +121,7 @@ namespace ReactNative.Shell
                 new ReactRunManager(),
                 //new RecyclerViewBackedScrollViewManager(),
                 new ReactScrollViewManager(),
+                new ReactSliderManager(),
                 new ReactSplitViewManager(),
                 new ReactSwitchManager(),
                 new ReactPasswordBoxManager(),
@@ -130,7 +131,6 @@ namespace ReactNative.Shell
                 new ReactSpanViewManager(),
                 //new SwipeRefreshLayoutManager(),
                 new ReactWebViewManager(),
-                new ReactSliderManager(),
             };
         }
     }

--- a/ReactWindows/ReactNative/UIManager/UIManagerModule.Constants.cs
+++ b/ReactWindows/ReactNative/UIManager/UIManagerModule.Constants.cs
@@ -188,20 +188,6 @@ namespace ReactNative.UIManager
                         { "registrationName", "onLayout" },
                     }
                 },
-                {
-                    "topValueChange",
-                    new Map
-                    {
-                        { "registrationName", "onValueChange" },
-                    }
-                },
-                {
-                    "topSlidingComplete",
-                    new Map
-                    {
-                        { "registrationName", "onSlidingComplete" },
-                    }
-                },
             };
         }
 

--- a/ReactWindows/ReactNative/Views/Slider/ReactSliderChangeEvent.cs
+++ b/ReactWindows/ReactNative/Views/Slider/ReactSliderChangeEvent.cs
@@ -18,8 +18,8 @@ namespace ReactNative.Views.Slider
         /// <param name="viewTag">The view tag.</param>
         /// <param name="value">Slider value.</param>
         public ReactSliderChangeEvent(int viewTag, double value)
-                : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
-            {
+            : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+        {
             _value = value;
         }
 
@@ -30,7 +30,7 @@ namespace ReactNative.Views.Slider
         {
             get
             {
-                return "topValueChange";
+                return "topChange";
             }
         }
 
@@ -41,10 +41,10 @@ namespace ReactNative.Views.Slider
         public override void Dispatch(RCTEventEmitter eventEmitter)
         {
             var eventData = new JObject
-                {
-                    { "target", ViewTag },
-                    { "value", _value },
-                };
+            {
+                { "target", ViewTag },
+                { "value", _value },
+            };
 
             eventEmitter.receiveEvent(ViewTag, EventName, eventData);
         }

--- a/ReactWindows/ReactNative/Views/Slider/ReactSliderCompleteEvent.cs
+++ b/ReactWindows/ReactNative/Views/Slider/ReactSliderCompleteEvent.cs
@@ -18,7 +18,7 @@ namespace ReactNative.Views.Slider
         /// <param name="viewTag">The view tag.</param>
         /// <param name="value">Slider value.</param>
         public ReactSliderCompleteEvent(int viewTag, double value)
-                : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+            : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
         {
             _value = value;
         }
@@ -41,10 +41,10 @@ namespace ReactNative.Views.Slider
         public override void Dispatch(RCTEventEmitter eventEmitter)
         {
             var eventData = new JObject
-                {
-                    { "target", ViewTag },
-                    { "value", _value },
-                };
+            {
+                { "target", ViewTag },
+                { "value", _value },
+            };
 
             eventEmitter.receiveEvent(ViewTag, EventName, eventData);
         }

--- a/ReactWindows/ReactNative/Views/Slider/ReactSliderManager.cs
+++ b/ReactWindows/ReactNative/Views/Slider/ReactSliderManager.cs
@@ -1,5 +1,6 @@
 using ReactNative.UIManager;
 using ReactNative.UIManager.Annotations;
+using System.Collections.Generic;
 using Windows.UI.Xaml;
 
 namespace ReactNative.Views.Slider
@@ -8,7 +9,9 @@ namespace ReactNative.Views.Slider
     /// A view manager responsible for rendering Slider.
     /// </summary>
     public class ReactSliderManager : BaseViewManager<Windows.UI.Xaml.Controls.Slider, ReactSliderShadowNode>
-    { 
+    {
+        private const double Undefined = double.NegativeInfinity;
+
         /// <summary>
         /// The name of the view manager.
         /// </summary>
@@ -17,6 +20,26 @@ namespace ReactNative.Views.Slider
             get
             {
                 return "RCTSlider";
+            }
+        }
+
+        /// <summary>
+        /// The exported custom direct event types.
+        /// </summary>
+        public override IReadOnlyDictionary<string, object> ExportedCustomDirectEventTypeConstants
+        {
+            get
+            {
+                return new Dictionary<string, object>
+                {
+                    {
+                        "topSlidingComplete",
+                        new Dictionary<string, object>()
+                        {
+                            { "registrationName", "onSlidingComplete" },
+                        }
+                    },
+                };
             }
         }
 
@@ -38,9 +61,7 @@ namespace ReactNative.Views.Slider
         /// Sets to change slider minimum value.
         /// </summary>
         /// <param name="view">a slider view.</param>
-        /// <param name="minimum">
-        /// The minimum slider value.
-        /// </param>
+        /// <param name="minimum">The minimum slider value.</param>
         [ReactProp("minimumValue")]
         public void SetMinimumValue(Windows.UI.Xaml.Controls.Slider view, double minimum)
         {
@@ -51,9 +72,7 @@ namespace ReactNative.Views.Slider
         /// Sets to change slider maximum value.
         /// </summary>
         /// <param name="view">a slider view.</param>
-        /// <param name="maximum">
-        /// The maximum slider value.
-        /// </param>
+        /// <param name="maximum">The maximum slider value.</param>
         [ReactProp("maximumValue")]
         public void SetMaximumValue(Windows.UI.Xaml.Controls.Slider view, double maximum)
         {
@@ -64,28 +83,35 @@ namespace ReactNative.Views.Slider
         /// Sets slider value.
         /// </summary>
         /// <param name="view">The slider view.</param>
-        /// <param name="value">
-        /// Slider value.
-        /// </param>
+        /// <param name="value">Slider value.</param>
         [ReactProp(ViewProps.Value)]
         public void SetValue(Windows.UI.Xaml.Controls.Slider view, double value)
         {
+            view.ValueChanged -= OnValueChange;
             view.Value = value;
+            view.ValueChanged += OnValueChange;
         }
 
         /// <summary>
         /// Sets slider step.
         /// </summary>
         /// <param name="view">The slider view.</param>
-        /// <param name="step">
-        /// Slider step.
-        /// </param>
-        [ReactProp("step")]
+        /// <param name="step">Slider step.</param>
+        [ReactProp("step", DefaultDouble = Undefined)]
         public void SetStep(Windows.UI.Xaml.Controls.Slider view, double step)
         {
-            if (step > 0)
+            if (step != Undefined)
             {
+                if (step == 0)
+                {
+                    step = double.Epsilon;
+                }
+
                 view.StepFrequency = step;
+            }
+            else
+            {
+                view.StepFrequency = 1;
             }
         }
 
@@ -100,6 +126,13 @@ namespace ReactNative.Views.Slider
             return new ReactSliderShadowNode();
         }
 
+        /// <summary>
+        /// Implement this method to receive optional extra data enqueued from
+        /// the corresponding instance of <see cref="ReactShadowNode"/> in
+        /// <see cref="ReactShadowNode.OnCollectExtraUpdates"/>.
+        /// </summary>
+        /// <param name="root">The root view.</param>
+        /// <param name="extraData">The extra data.</param>
         public override void UpdateExtraData(Windows.UI.Xaml.Controls.Slider root, object extraData)
         {
         }
@@ -111,10 +144,7 @@ namespace ReactNative.Views.Slider
         /// <returns></returns>
         protected override Windows.UI.Xaml.Controls.Slider CreateViewInstance(ThemedReactContext reactContext)
         {
-            return new Windows.UI.Xaml.Controls.Slider()
-            {
-                StepFrequency = 0.000001
-            };
+            return new Windows.UI.Xaml.Controls.Slider();
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative/Views/Slider/ReactSliderManager.cs
+++ b/ReactWindows/ReactNative/Views/Slider/ReactSliderManager.cs
@@ -10,6 +10,7 @@ namespace ReactNative.Views.Slider
     /// </summary>
     public class ReactSliderManager : BaseViewManager<Windows.UI.Xaml.Controls.Slider, ReactSliderShadowNode>
     {
+        private const double Epsilon = 1e-4;
         private const double Undefined = double.NegativeInfinity;
 
         /// <summary>
@@ -104,7 +105,7 @@ namespace ReactNative.Views.Slider
             {
                 if (step == 0)
                 {
-                    step = double.Epsilon;
+                    step = Epsilon;
                 }
 
                 view.StepFrequency = step;


### PR DESCRIPTION
Removes global declaration of the `topSlidingComplete` event in favor of a local declaration of the direct event type in the view manager.

Adds an `Undefined` value for the slider that will reset the value to XAML defaults.

Sets the step value to `Epsilon` (= 0.0001) when set to 0 from React.

cc @souhe