### PR TITLE
fix(DevSupport): Remove cached bundle for failed calls to packager

### DIFF
--- a/ReactWindows/ReactNative/DevSupport/DevSupportManager.cs
+++ b/ReactWindows/ReactNative/DevSupport/DevSupportManager.cs
@@ -434,6 +434,7 @@ namespace ReactNative.DevSupport
 
         private async Task ReloadJavaScriptFromServerAsync(Action dismissProgress, CancellationToken token)
         {
+            var downloaded = false;
             var localFolder = ApplicationData.Current.LocalFolder;
             var localFile = await localFolder.CreateFileAsync(JSBundleFileName, CreationCollisionOption.ReplaceExisting);
             try
@@ -445,6 +446,7 @@ namespace ReactNative.DevSupport
 
                 dismissProgress();
                 _reactInstanceCommandsHandler.OnJavaScriptBundleLoadedFromServer();
+                downloaded = true;
             }
             catch (DebugServerException ex)
             {
@@ -458,6 +460,13 @@ namespace ReactNative.DevSupport
                     "Unable to download JS bundle. Did you forget to " +
                     "start the development server or connect your device?",
                     ex);
+            }
+            finally
+            {
+                if (!downloaded)
+                {
+                    await localFile.DeleteAsync();
+                }
             }
         }
 


### PR DESCRIPTION
This set of changes ensures that, in case the packager server is not online or otherwise fails, the intermediate bundle file is deleted.  In order to always keep a valid bundle in the LocalState if such a bundle has ever been produced, we use a temporary file and only move it to LocalState once the packager server request succeeds.

Fixes #671