### PR TITLE
fix(Playground): Disable dev support for ReleaseBundle configuration

### DIFF
--- a/ReactWindows/Playground/AppReactPage.cs
+++ b/ReactWindows/Playground/AppReactPage.cs
@@ -48,7 +48,11 @@ namespace Playground
         {
             get
             {
+#if !BUNDLE || DEBUG
                 return true;
+#else
+                return false;
+#endif
             }
         }
     }


### PR DESCRIPTION
We don't want to disable dev support for all Release builds (the 'Release' configuration still expects to communicate with the bundle server). Instead, we'll just disable it for the ReleaseBundle configuration.

Towards #692