### PR TITLE
Proper declaration of minimum peer dependecies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,10 @@
     "README.md"
   ],
   "peerDependencies": {
-    "react-native": "0.33.0-rc.0",
-    "react": "~15.3.1"
+    "react": "~15.3.1-rc.2"
   },
   "devDependencies": {
-    "react-native": "0.33.0-rc.0",
-    "react": "~15.3.1"
+    "react-native": "0.33.0-rc.0"
   },
   "dependencies": {
     "chalk": "^1.1.3",


### PR DESCRIPTION
npm install didn't work. A non rc version of react was referenced in the peer as well as the dev dependencies, but an rc version is actually required it appears.