### PR TITLE
fix(Devtools): Make devtools a no-op

### DIFF
--- a/Libraries/Devtools/setupDevtools.windows.js
+++ b/Libraries/Devtools/setupDevtools.windows.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule setupDevtools
+ * @flow
+ */
+'use strict';
+
+function setupDevtools() {
+  // No-op on Windows
+}
+
+module.exports = setupDevtools;


### PR DESCRIPTION
Getting a lot of issues filed because of exceptions thrown from WebSocket module. This tend to come from the devtools setup which no one (currently) seems to be using for Windows.  We can delete the added file at some point when devtools should be enabled for Windows.

Fixes #701