### PR TITLE
fix(ReactContext): Dispose path for ReactContext created deadlock

### DIFF
--- a/ReactWindows/ReactNative.Tests/Bridge/ReactInstanceTests.cs
+++ b/ReactWindows/ReactNative.Tests/Bridge/ReactInstanceTests.cs
@@ -49,7 +49,7 @@ namespace ReactNative.Tests.Bridge
             var secondJSModule = instance.GetJavaScriptModule<TestJavaScriptModule>();
             Assert.AreSame(firstJSModule, secondJSModule);
 
-            await DispatcherHelpers.RunOnDispatcherAsync(instance.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(instance.DisposeAsync);
         }
 
         [TestMethod]
@@ -98,11 +98,11 @@ namespace ReactNative.Tests.Bridge
             Assert.IsTrue(caught);
             Assert.AreEqual(1, module.InitializeCalls);
 
-            await DispatcherHelpers.RunOnDispatcherAsync(() => instance.Dispose());
+            await DispatcherHelpers.CallOnDispatcherAsync(instance.DisposeAsync);
             Assert.AreEqual(1, module.OnReactInstanceDisposeCalls);
 
             // Dispose is idempotent
-            await DispatcherHelpers.RunOnDispatcherAsync(() => instance.Dispose());
+            await DispatcherHelpers.CallOnDispatcherAsync(instance.DisposeAsync);
             Assert.AreEqual(1, module.OnReactInstanceDisposeCalls);
 
             Assert.IsTrue(instance.IsDisposed);

--- a/ReactWindows/ReactNative.Tests/Internal/MockReactInstance.cs
+++ b/ReactWindows/ReactNative.Tests/Internal/MockReactInstance.cs
@@ -4,6 +4,7 @@ using ReactNative.Bridge.Queue;
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace ReactNative.Tests
 {
@@ -84,9 +85,10 @@ namespace ReactNative.Tests
             _function(module, method, arguments, tracingName);
         }
 
-        public void Dispose()
+        public Task DisposeAsync()
         {
             Interlocked.Increment(ref _isDisposed);
+            return Task.CompletedTask;
         }
     }
 }

--- a/ReactWindows/ReactNative.Tests/Modules/Core/TimingTests.cs
+++ b/ReactWindows/ReactNative.Tests/Modules/Core/TimingTests.cs
@@ -34,7 +34,7 @@ namespace ReactNative.Tests.Modules.Core
             Assert.IsTrue(waitHandle.WaitOne(1000));
             Assert.IsTrue(new[] { 42 }.SequenceEqual(ids));
 
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         [TestMethod]
@@ -66,7 +66,7 @@ namespace ReactNative.Tests.Modules.Core
 
             Assert.IsTrue(countdown.Wait(count * 2));
 
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         [TestMethod]
@@ -91,7 +91,7 @@ namespace ReactNative.Tests.Modules.Core
             timing.deleteTimer(id);
             Assert.IsFalse(waitHandle.WaitOne(1000));
 
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         [TestMethod]
@@ -117,7 +117,7 @@ namespace ReactNative.Tests.Modules.Core
             Assert.IsFalse(waitHandle.WaitOne(1000));
             await DispatcherHelpers.RunOnDispatcherAsync(context.OnResume);
             Assert.IsTrue(waitHandle.WaitOne(1000));
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         [TestMethod]
@@ -152,7 +152,7 @@ namespace ReactNative.Tests.Modules.Core
             Assert.AreEqual(42, ids.Distinct().SingleOrDefault());
             Assert.IsTrue(ids.Count >= repeat);
 
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         [TestMethod]
@@ -195,7 +195,7 @@ namespace ReactNative.Tests.Modules.Core
             countdown.Signal();
             Assert.IsTrue(countdown.Wait(batchCount * maxDuration / 4 * 2));
 
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         [TestMethod]
@@ -245,7 +245,7 @@ namespace ReactNative.Tests.Modules.Core
 
             Assert.IsTrue(waitHandle.WaitOne());
 
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         [TestMethod]
@@ -269,7 +269,7 @@ namespace ReactNative.Tests.Modules.Core
 
             Assert.IsTrue(new[] { 42 }.SequenceEqual(ids));
 
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         [TestMethod]
@@ -293,7 +293,7 @@ namespace ReactNative.Tests.Modules.Core
             countdown.Wait();
             timing.deleteTimer(42);
 
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         [TestMethod]
@@ -320,7 +320,7 @@ namespace ReactNative.Tests.Modules.Core
             Assert.IsTrue(ids.SequenceEqual(new[] { 2 }));
             timing.deleteTimer(1);
 
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         private static ReactContext CreateReactContext(IInvocationHandler handler)

--- a/ReactWindows/ReactNative.Tests/ReactInstanceManagerTests.cs
+++ b/ReactWindows/ReactNative.Tests/ReactInstanceManagerTests.cs
@@ -219,7 +219,7 @@ namespace ReactNative.Tests
             });
 
             var completedTask = await Task.WhenAny(
-                Task.Delay(50000),
+                Task.Delay(5000),
                 tcs.Task);
 
             Assert.IsTrue(tcs.Task.IsCompleted);

--- a/ReactWindows/ReactNative.Tests/ReactInstanceManagerTests.cs
+++ b/ReactWindows/ReactNative.Tests/ReactInstanceManagerTests.cs
@@ -47,7 +47,7 @@ namespace ReactNative.Tests
                 () => manager.OnResume(null),
                 ex => Assert.AreEqual("onBackPressed", ex.ParamName));
 
-            await DispatcherHelpers.RunOnDispatcherAsync(manager.OnDestroy);
+            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
         }
 
         [TestMethod]
@@ -65,7 +65,7 @@ namespace ReactNative.Tests
             Assert.IsTrue(waitHandle.WaitOne());
             Assert.AreEqual(jsBundleFile, manager.SourceUrl);
 
-            await DispatcherHelpers.RunOnDispatcherAsync(manager.OnDestroy);
+            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
         }
 
         [TestMethod]
@@ -94,7 +94,7 @@ namespace ReactNative.Tests
 
             Assert.IsTrue(caught);
 
-            await DispatcherHelpers.RunOnDispatcherAsync(manager.OnDestroy);
+            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
         }
 
         [TestMethod]
@@ -116,7 +116,7 @@ namespace ReactNative.Tests
             Assert.IsTrue(waitHandle.WaitOne());
             Assert.AreEqual(jsBundleFile, manager.SourceUrl);
 
-            await DispatcherHelpers.RunOnDispatcherAsync(manager.OnDestroy);
+            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
         }
 
         [TestMethod]
@@ -140,7 +140,7 @@ namespace ReactNative.Tests
 
             Assert.IsTrue(caught);
 
-            await DispatcherHelpers.RunOnDispatcherAsync(manager.OnDestroy);
+            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
         }
 
         [TestMethod]
@@ -156,7 +156,7 @@ namespace ReactNative.Tests
 
             Assert.IsTrue(waitHandle.WaitOne());
 
-            await DispatcherHelpers.RunOnDispatcherAsync(manager.OnDestroy);
+            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
         }
 
         [TestMethod]
@@ -174,14 +174,55 @@ namespace ReactNative.Tests
             Assert.IsTrue(waitHandle.WaitOne());
             Assert.AreEqual(jsBundleFile, manager.SourceUrl);
 
-            await DispatcherHelpers.RunOnDispatcherAsync(manager.OnDestroy);
+            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
 
             await DispatcherHelpers.RunOnDispatcherAsync(
                 () => manager.CreateReactContextInBackground());
 
             Assert.IsTrue(waitHandle.WaitOne());
 
-            await DispatcherHelpers.RunOnDispatcherAsync(manager.OnDestroy);
+            await DispatcherHelpers.CallOnDispatcherAsync(manager.DisposeAsync);
+        }
+
+        [TestMethod]
+        public async Task ReactInstanceManager_DisposeAsync_WhileBusy()
+        {
+            var jsBundleFile = "ms-appx:///Resources/test.js";
+            var manager = CreateReactInstanceManager(jsBundleFile);
+
+            var initializedEvent = new AutoResetEvent(false);
+            manager.ReactContextInitialized += (sender, args) => initializedEvent.Set();
+
+            await DispatcherHelpers.CallOnDispatcherAsync(async () =>
+            {
+                await manager.CreateReactContextInBackgroundAsync();
+            });
+
+            var e = new AutoResetEvent(false);
+
+            initializedEvent.WaitOne();
+            manager.CurrentReactContext.RunOnNativeModulesQueueThread(() =>
+            {
+                e.WaitOne();
+                var x = DispatcherHelpers.CallOnDispatcherAsync(() =>
+                {
+                    return 42;
+                }).Result;
+            });
+
+            var tcs = new TaskCompletionSource<bool>();
+            await DispatcherHelpers.RunOnDispatcherAsync(async () =>
+            {
+                e.Set();
+                await manager.DisposeAsync();
+                await Task.Run(() => tcs.SetResult(true));
+            });
+
+            var completedTask = await Task.WhenAny(
+                Task.Delay(50000),
+                tcs.Task);
+
+            Assert.IsTrue(tcs.Task.IsCompleted);
         }
 
         private static ReactInstanceManager CreateReactInstanceManager()

--- a/ReactWindows/ReactNative.Tests/UIManager/Events/EventDispatcherTests.cs
+++ b/ReactWindows/ReactNative.Tests/UIManager/Events/EventDispatcherTests.cs
@@ -23,7 +23,7 @@ namespace ReactNative.Tests.UIManager.Events
             var context = new ReactContext();
             var dispatcher = new EventDispatcher(context);
             AssertEx.Throws<ArgumentNullException>(() => dispatcher.DispatchEvent(null), ex => Assert.AreEqual("event", ex.ParamName));
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         [TestMethod]
@@ -37,7 +37,7 @@ namespace ReactNative.Tests.UIManager.Events
             AssertEx.Throws<InvalidOperationException>(() => dispatcher.OnSuspend());
             AssertEx.Throws<InvalidOperationException>(() => dispatcher.OnReactInstanceDispose());
 
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         [TestMethod]
@@ -65,7 +65,7 @@ namespace ReactNative.Tests.UIManager.Events
 
             Assert.IsTrue(waitDispatched.WaitOne());
 
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         [TestMethod]
@@ -100,7 +100,7 @@ namespace ReactNative.Tests.UIManager.Events
             Assert.IsTrue(waitDispatched.WaitOne());
             Assert.IsTrue(waitDispatched.WaitOne());
 
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         [TestMethod]
@@ -130,7 +130,7 @@ namespace ReactNative.Tests.UIManager.Events
                 Assert.IsTrue(waitDispatched.WaitOne());
             }
 
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         [TestMethod]
@@ -174,7 +174,7 @@ namespace ReactNative.Tests.UIManager.Events
             // Second event is disposed after dispatch
             Assert.IsTrue(disposed.WaitOne());
 
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         [TestMethod]
@@ -218,7 +218,7 @@ namespace ReactNative.Tests.UIManager.Events
             // Second event is disposed after dispatch
             Assert.IsTrue(disposed.WaitOne());
 
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         [TestMethod]
@@ -270,7 +270,7 @@ namespace ReactNative.Tests.UIManager.Events
                 Assert.IsTrue(waitDispatched.WaitOne());
             }
 
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         [TestMethod]
@@ -302,7 +302,7 @@ namespace ReactNative.Tests.UIManager.Events
 
             Assert.IsFalse(waitDispatched.WaitOne(500));
 
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         [TestMethod]
@@ -334,7 +334,7 @@ namespace ReactNative.Tests.UIManager.Events
 
             Assert.IsFalse(waitDispatched.WaitOne(500));
 
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         [TestMethod]
@@ -366,7 +366,7 @@ namespace ReactNative.Tests.UIManager.Events
 
             Assert.IsFalse(waitDispatched.WaitOne(500));
 
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         [TestMethod]
@@ -398,7 +398,7 @@ namespace ReactNative.Tests.UIManager.Events
             await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnResume);
             Assert.IsTrue(waitDispatched.WaitOne());
 
-            await DispatcherHelpers.RunOnDispatcherAsync(context.Dispose);
+            await DispatcherHelpers.CallOnDispatcherAsync(context.DisposeAsync);
         }
 
         private static async Task<ReactContext> CreateContextAsync(IJavaScriptExecutor executor)

--- a/ReactWindows/ReactNative/Bridge/IAsyncCancelable.cs
+++ b/ReactWindows/ReactNative/Bridge/IAsyncCancelable.cs
@@ -1,0 +1,13 @@
+﻿namespace ReactNative.Bridge
+{
+    /// <summary>
+    /// Asynchronous disposable resource with disposal state tracking.
+    /// </summary>
+    public interface IAsyncCancelable : IAsyncDisposable
+    {
+        /// <summary>
+        /// Gets a value that indicates whether the object is disposed.
+        /// </summary>
+        bool IsDisposed { get; }
+    }
+}

--- a/ReactWindows/ReactNative/Bridge/IAsyncDisposable.cs
+++ b/ReactWindows/ReactNative/Bridge/IAsyncDisposable.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+
+namespace ReactNative.Bridge
+{
+    /// <summary>
+    /// A resource that can be disposed asynchronously.
+    /// </summary>
+    public interface IAsyncDisposable
+    {
+        /// <summary>
+        /// Asynchronously disposes the instance.
+        /// </summary>
+        /// <returns>A task to await dispose operation.</returns>
+        Task DisposeAsync();
+    }
+}

--- a/ReactWindows/ReactNative/Bridge/IReactInstance.cs
+++ b/ReactWindows/ReactNative/Bridge/IReactInstance.cs
@@ -1,7 +1,6 @@
 ﻿using Newtonsoft.Json.Linq;
 using ReactNative.Bridge.Queue;
 using System.Collections.Generic;
-using System.Reactive.Disposables;
 
 namespace ReactNative.Bridge
 {
@@ -10,7 +9,7 @@ namespace ReactNative.Bridge
     /// environment allowing the invocation of JavaScript methods and lets a
     /// set of native APIs be invokable from JavaScript as well.
     /// </summary>
-    public interface IReactInstance : ICancelable
+    public interface IReactInstance : IAsyncCancelable
     {
         /// <summary>
         /// Enumerates the available native modules.

--- a/ReactWindows/ReactNative/Bridge/ReactContext.cs
+++ b/ReactWindows/ReactNative/Bridge/ReactContext.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace ReactNative.Bridge
 {
@@ -11,7 +12,7 @@ namespace ReactNative.Bridge
     /// Abstract context wrapper for the React instance to manage
     /// lifecycle events.
     /// </summary>
-    public class ReactContext : IDisposable
+    public class ReactContext : IAsyncDisposable
     {
         private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();
         private readonly List<ILifecycleEventListener> _lifecycleEventListeners =
@@ -164,7 +165,7 @@ namespace ReactNative.Bridge
         /// <summary>
         /// Called by the host when the application shuts down.
         /// </summary>
-        public void Dispose()
+        public async Task DisposeAsync()
         {
             DispatcherHelpers.AssertOnDispatcher();
 
@@ -188,7 +189,7 @@ namespace ReactNative.Bridge
             var reactInstance = _reactInstance;
             if (reactInstance != null)
             {
-                reactInstance.Dispose();
+                await reactInstance.DisposeAsync().ConfigureAwait(false);
             }
 
             _lock.Dispose();

--- a/ReactWindows/ReactNative/Bridge/ReactInstance.cs
+++ b/ReactWindows/ReactNative/Bridge/ReactInstance.cs
@@ -215,7 +215,8 @@ namespace ReactNative.Bridge
         private void HandleException(Exception ex)
         {
             _nativeModuleCallExceptionHandler(ex);
-            QueueConfiguration.DispatcherQueueThread.RunOnQueue(async () => await DisposeAsync());
+            QueueConfiguration.DispatcherQueueThread.RunOnQueue(async () => 
+                await DisposeAsync().ConfigureAwait(false));
         }
 
         public sealed class Builder

--- a/ReactWindows/ReactNative/Bridge/ReactInstance.cs
+++ b/ReactWindows/ReactNative/Bridge/ReactInstance.cs
@@ -16,7 +16,7 @@ namespace ReactNative.Bridge
     /// A higher level API on top of the <see cref="IJavaScriptExecutor" /> and module registries. This provides an
     /// environment allowing the invocation of JavaScript methods.
     /// </summary>
-    class ReactInstance : IReactInstance, IDisposable
+    class ReactInstance : IReactInstance, IAsyncDisposable
     {
         private readonly NativeModuleRegistry _registry;
         private readonly JavaScriptModuleRegistry _jsRegistry;
@@ -167,7 +167,7 @@ namespace ReactNative.Bridge
             });
         }
 
-        public void Dispose()
+        public async Task DisposeAsync()
         {
             DispatcherHelpers.AssertOnDispatcher();
 
@@ -179,13 +179,13 @@ namespace ReactNative.Bridge
             IsDisposed = true;
             _registry.NotifyReactInstanceDispose();
 
-            QueueConfiguration.JavaScriptQueueThread.CallOnQueue(() =>
+            await QueueConfiguration.JavaScriptQueueThread.CallOnQueue(() =>
             {
                 using (_bridge) { }
                 return true;
-            }).Wait();
+            }).ConfigureAwait(false);
 
-            QueueConfiguration.Dispose();
+            await Task.Run(new Action(QueueConfiguration.Dispose)).ConfigureAwait(false);
         }
 
         private string BuildModulesConfig()
@@ -215,7 +215,7 @@ namespace ReactNative.Bridge
         private void HandleException(Exception ex)
         {
             _nativeModuleCallExceptionHandler(ex);
-            QueueConfiguration.DispatcherQueueThread.RunOnQueue(Dispose);
+            QueueConfiguration.DispatcherQueueThread.RunOnQueue(async () => await DisposeAsync());
         }
 
         public sealed class Builder

--- a/ReactWindows/ReactNative/IReactInstanceManager.cs
+++ b/ReactWindows/ReactNative/IReactInstanceManager.cs
@@ -4,6 +4,7 @@ using ReactNative.Modules.Core;
 using ReactNative.UIManager;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace ReactNative
 {
@@ -23,9 +24,9 @@ namespace ReactNative
     /// <see cref="ReactRootView"/> that is used to render the React 
     /// application using this instance manager. It is required to pass
     /// lifecycle events to the instance manager (i.e., <see cref="OnSuspend"/>,
-    /// <see cref="OnDestroy"/>, and <see cref="OnResume(Action)"/>).
+    /// <see cref="IAsyncDisposable.DisposeAsync"/>, and <see cref="OnResume(Action)"/>).
     /// </summary>
-    public interface IReactInstanceManager
+    public interface IReactInstanceManager : IAsyncDisposable
     {
         /// <summary>
         /// Event triggered when a React context has been initialized.
@@ -39,8 +40,9 @@ namespace ReactNative
 
         /// <summary>
         /// Signals whether <see cref="CreateReactContextInBackground"/> has 
-        /// been called. Will return <code>false</code> after  <see cref="OnDestroy"/>
-        /// until a new initial context has been created.
+        /// been called. Will return <code>false</code> after 
+        /// <see cref="IAsyncDisposable.DisposeAsync"/> until a new initial 
+        /// context has been created.
         /// </summary>
         bool HasStartedCreatingInitialContext { get; }
 
@@ -86,11 +88,6 @@ namespace ReactNative
         /// The action to take when back is pressed.
         /// </param>
         void OnResume(Action onBackPressed);
-
-        /// <summary>
-        /// Destroy the <see cref="IReactInstanceManager"/>.
-        /// </summary>
-        void OnDestroy();
 
         /// <summary>
         /// Attach given <paramref name="rootView"/> to a React instance

--- a/ReactWindows/ReactNative/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative/ReactInstanceManager.cs
@@ -30,7 +30,7 @@ namespace ReactNative
     /// <see cref="ReactRootView"/> that is used to render the React
     /// application using this instance manager. It is required to pass
     /// lifecycle events to the instance manager (i.e., <see cref="OnSuspend"/>,
-    /// <see cref="OnDestroy"/>, and <see cref="OnResume(Action)"/>).
+    /// <see cref="IAsyncDisposable.DisposeAsync"/>, and <see cref="OnResume(Action)"/>).
     /// </summary>
     public class ReactInstanceManager : IReactInstanceManager
     {
@@ -102,8 +102,9 @@ namespace ReactNative
 
         /// <summary>
         /// Signals whether <see cref="CreateReactContextInBackground"/> has
-        /// been called. Will return <code>false</code> after  <see cref="OnDestroy"/>
-        /// until a new initial context has been created.
+        /// been called. Will return <code>false</code> after 
+        /// <see cref="IAsyncDisposable.DisposeAsync"/>  until a new initial
+        /// context has been created.
         /// </summary>
         public bool HasStartedCreatingInitialContext
         {
@@ -277,7 +278,7 @@ namespace ReactNative
         /// <summary>
         /// Destroy the <see cref="IReactInstanceManager"/>.
         /// </summary>
-        public void OnDestroy()
+        public async Task DisposeAsync()
         {
             DispatcherHelpers.AssertOnDispatcher();
 
@@ -290,7 +291,7 @@ namespace ReactNative
             var currentReactContext = _currentReactContext;
             if (currentReactContext != null)
             {
-                currentReactContext.Dispose();
+                await currentReactContext.DisposeAsync();
                 _currentReactContext = null;
                 _hasStartedCreatingInitialContext = false;
             }
@@ -450,7 +451,7 @@ namespace ReactNative
             var currentReactContext = _currentReactContext;
             if (currentReactContext != null)
             {
-                TearDownReactContext(currentReactContext);
+                await TearDownReactContextAsync(currentReactContext);
                 _currentReactContext = null;
             }
 
@@ -537,7 +538,7 @@ namespace ReactNative
             reactInstance.GetJavaScriptModule<AppRegistry>().unmountApplicationComponentAtRootTag(rootView.GetTag());
         }
 
-        private void TearDownReactContext(ReactContext reactContext)
+        private async Task TearDownReactContextAsync(ReactContext reactContext)
         {
             DispatcherHelpers.AssertOnDispatcher();
 
@@ -551,7 +552,7 @@ namespace ReactNative
                 DetachViewFromInstance(rootView, reactContext.ReactInstance);
             }
 
-            reactContext.Dispose();
+            await reactContext.DisposeAsync();
             _devSupportManager.OnReactContextDestroyed(reactContext);
             // TODO: add memory pressure hooks
         }

--- a/ReactWindows/ReactNative/ReactInstanceManager.cs
+++ b/ReactWindows/ReactNative/ReactInstanceManager.cs
@@ -291,7 +291,7 @@ namespace ReactNative
             var currentReactContext = _currentReactContext;
             if (currentReactContext != null)
             {
-                await currentReactContext.DisposeAsync();
+                await currentReactContext.DisposeAsync().ConfigureAwait(false);
                 _currentReactContext = null;
                 _hasStartedCreatingInitialContext = false;
             }

--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -131,6 +131,8 @@
     <Compile Include="Animated\ValueAnimatedNode.cs" />
     <Compile Include="Bridge\BridgeBusyEventArgs.cs" />
     <Compile Include="Bridge\BridgeIdleEventArgs.cs" />
+    <Compile Include="Bridge\IAsyncCancelable.cs" />
+    <Compile Include="Bridge\IAsyncDisposable.cs" />
     <Compile Include="Bridge\ILifecycleEventListener.cs" />
     <Compile Include="Bridge\IPromise.cs" />
     <Compile Include="Bridge\ReactInstance.cs" />

--- a/ReactWindows/ReactNative/ReactPage.cs
+++ b/ReactWindows/ReactNative/ReactPage.cs
@@ -1,12 +1,12 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using ReactNative.Bridge;
 using ReactNative.Modules.Core;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Windows.System;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 
 namespace ReactNative
@@ -14,7 +14,7 @@ namespace ReactNative
     /// <summary>
     /// Base page for React Native applications.
     /// </summary>
-    public abstract class ReactPage : Page
+    public abstract class ReactPage : Page, IAsyncDisposable
     {
         private readonly IReactInstanceManager _reactInstanceManager;
 
@@ -124,11 +124,11 @@ namespace ReactNative
         /// <summary>
         /// Called before the application shuts down.
         /// </summary>
-        public void OnDestroy()
+        public Task DisposeAsync()
         {
-            _reactInstanceManager.OnDestroy();
-            
             Window.Current.CoreWindow.Dispatcher.AcceleratorKeyActivated -= OnAcceleratorKeyActivated;
+
+            return _reactInstanceManager.DisposeAsync();            
         }
 
         /// <summary>


### PR DESCRIPTION
Basic overview of the deadlock:
1) CSS layout operation in progress
2) Text node measurement started on native module thread
3) ReactContext disposed on dispatcher thread
4) ReactContext disposal blocks on completion of native module thread
5) Native module thread blocks on dispatcher operation for text measurement
6) We have deadlock

The best way to get around this is to not block from the native module thread, but this is a limitation we haven't figured out how to work around yet.  In the meantime, it actually makes sense to make the teardown process for the React context asynchronous, which is what this changeset does.

Fixes #702