### PR TITLE
fix(AsyncStorage): ensure getAllKeys from filenames are translated

### DIFF
--- a/ReactWindows/ReactNative.Tests/Modules/Storage/AsyncStorageModuleTests.cs
+++ b/ReactWindows/ReactNative.Tests/Modules/Storage/AsyncStorageModuleTests.cs
@@ -41,6 +41,55 @@ namespace ReactNative.Tests.Modules.Storage
             Assert.AreEqual(error["message"], "Invalid Value");
             Assert.IsNull(result);
         }
+       
+        [TestMethod]
+        public void AsyncStorageModule_GetAllKeys_Valid()
+        {
+            var module = new AsyncStorageModule();
+            var waitHandle = new AutoResetEvent(false);
+
+            var error = default(JObject);
+            var result = default(JArray);
+            var callback = new MockCallback(res =>
+            {
+                error = res.Length > 0 ? (JObject)res[0] : null;
+                result = res.Length > 1 ? (JArray)res[1] : null;
+                waitHandle.Set();
+            });
+
+            module.clear(callback);
+            Assert.IsTrue(waitHandle.WaitOne());
+            Assert.IsNull(error);
+            Assert.IsNull(result);
+
+            var pairs = new[]
+            {
+                new[] { "\\", "1" },
+                new[] { "/", "2" },
+                new[] { ":", "3" },
+                new[] { "*", "4" },
+                new[] { "?", "5" },
+                new[] { "<", "6" },
+                new[] { ">", "7" },
+                new[] { "|", "8" },
+                new[] { "\"", "9" },
+                new[] { ".", "10" },
+                new[] { "{", "11" },
+                new[] { "}", "12" },
+            };
+
+            module.multiSet(pairs, callback);
+            Assert.IsTrue(waitHandle.WaitOne());
+            Assert.IsNull(error);
+            Assert.IsNull(result);
+
+            module.getAllKeys(callback);
+            Assert.IsTrue(waitHandle.WaitOne());
+            Assert.IsNull(error);
+            var expectedKeys = pairs.Select(arr => arr[0]).OrderBy(s => s);
+            var actualKeys = result.ToObject<string[]>().OrderBy(s => s);
+            Assert.IsTrue(expectedKeys.SequenceEqual(actualKeys));
+        }
 
         [TestMethod]
         public void AsyncStorageModule_multiGet_Method()
@@ -184,8 +233,8 @@ namespace ReactNative.Tests.Modules.Storage
             Assert.IsTrue(waitHandle.WaitOne());
             Assert.IsNull(error);
             Assert.AreEqual(
-                JArray.FromObject(array).ToString(Formatting.None),
-                result.ToString(Formatting.None));
+            JArray.FromObject(array).ToString(Formatting.None),
+            result.ToString(Formatting.None));
         }
 
         [TestMethod]

--- a/ReactWindows/ReactNative.Tests/Modules/Storage/AsyncStorageModuleTests.cs
+++ b/ReactWindows/ReactNative.Tests/Modules/Storage/AsyncStorageModuleTests.cs
@@ -43,7 +43,7 @@ namespace ReactNative.Tests.Modules.Storage
         }
        
         [TestMethod]
-        public void AsyncStorageModule_GetAllKeys_Valid()
+        public void AsyncStorageModule_GetAllKeys_SpecialCharacters()
         {
             var module = new AsyncStorageModule();
             var waitHandle = new AutoResetEvent(false);
@@ -76,6 +76,9 @@ namespace ReactNative.Tests.Modules.Storage
                 new[] { ".", "10" },
                 new[] { "{", "11" },
                 new[] { "}", "12" },
+                new[] { "\\/:*?<>|\".{}", "13" },
+                new[] { "abc\\abc/abc:abc*abc?abc<abc>abc|abc\"abc.abc{abc}abc", "13" },
+                new[] { "foo:bar", "14" },
             };
 
             module.multiSet(pairs, callback);

--- a/ReactWindows/ReactNative/Modules/Storage/AsyncStorageModule.cs
+++ b/ReactWindows/ReactNative/Modules/Storage/AsyncStorageModule.cs
@@ -377,7 +377,7 @@ namespace ReactNative.Modules.Storage
             {
                 var localFolder = ApplicationData.Current.LocalFolder;
                 var storageFolderItem = await localFolder.TryGetItemAsync(DirectoryName);
-                _cachedFolder = storageFolderItem == null && createIfNotExists
+                _cachedFolder = storageFolderItem != null || createIfNotExists
                     ? await localFolder.CreateFolderAsync(DirectoryName, CreationCollisionOption.OpenIfExists)
                     : null;
             }

--- a/ReactWindows/ReactNative/Modules/Storage/AsyncStorageModule.cs
+++ b/ReactWindows/ReactNative/Modules/Storage/AsyncStorageModule.cs
@@ -36,9 +36,9 @@ namespace ReactNative.Modules.Storage
 
         private static readonly int s_maxReplace = s_charToString.Values.Select(s => s.Length).Max();
 
-        private static StorageFolder s_cachedFolder;
-
         private readonly SemaphoreSlim _mutex = new SemaphoreSlim(1, 1);
+
+        private StorageFolder s_cachedFolder;
 
         public override string Name
         {
@@ -370,7 +370,7 @@ namespace ReactNative.Modules.Storage
             return default(JObject);
         }
 
-        private static async Task<StorageFolder> GetAsyncStorageFolder(bool createIfNotExists)
+        private async Task<StorageFolder> GetAsyncStorageFolder(bool createIfNotExists)
         {
             if (s_cachedFolder == null)
             {

--- a/ReactWindows/ReactNative/Modules/Storage/AsyncStorageModule.cs
+++ b/ReactWindows/ReactNative/Modules/Storage/AsyncStorageModule.cs
@@ -428,7 +428,7 @@ namespace ReactNative.Modules.Storage
                 if (start == '{')
                 {
                     var j = i;
-                    while (j < fileName.Length && (j - i) < s_maxReplace)
+                    while (j < length && (j - i) < s_maxReplace)
                     {
                         var end = fileName[++j];
                         if (end == '}')

--- a/ReactWindows/ReactNative/Modules/Storage/AsyncStorageModule.cs
+++ b/ReactWindows/ReactNative/Modules/Storage/AsyncStorageModule.cs
@@ -2,6 +2,8 @@
 using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,8 +13,30 @@ namespace ReactNative.Modules.Storage
 {
     class AsyncStorageModule : NativeModuleBase, ILifecycleEventListener
     {
-        private const string DirectoryName = "AsyncStorage\\";
+        private const string DirectoryName = "AsyncStorage";
         private const string FileExtension = ".data";
+        
+        private static readonly IDictionary<char, string> s_charToString = new Dictionary<char, string>
+        {
+            { '\\', "{bsl}" },
+            { '/', "{fsl}" },
+            { ':', "{col}" },
+            { '*', "{asx}" },
+            { '?', "{q}" },
+            { '<', "{gt}" },
+            { '>', "{lt}" },
+            { '|', "{bar}" },
+            { '\"', "{quo}" },
+            { '.', "{dot}" },
+            { '{', "{ocb}" },
+            { '}', "{ccb}" },
+        };
+
+        private static readonly IDictionary<string, char> s_stringToChar = s_charToString.ToDictionary(kv => kv.Value, kv => kv.Key);
+
+        private static readonly int s_maxReplace = s_charToString.Values.Select(s => s.Length).Max();
+
+        private static StorageFolder s_cachedFolder;
 
         private readonly SemaphoreSlim _mutex = new SemaphoreSlim(1, 1);
 
@@ -251,20 +275,15 @@ namespace ReactNative.Modules.Storage
             await _mutex.WaitAsync().ConfigureAwait(false);
             try
             {
-                var localFolder = ApplicationData.Current.LocalFolder;
-                var storageItem = await localFolder.TryGetItemAsync(DirectoryName).AsTask().ConfigureAwait(false);
-                if (storageItem != null)
+                var storageFolder = await GetAsyncStorageFolder(false);
+                if (storageFolder != null)
                 {
-                    var directory = await localFolder.GetFolderAsync(DirectoryName).AsTask().ConfigureAwait(false);
-                    var items = await directory.GetItemsAsync().AsTask().ConfigureAwait(false);
+                    var items = await storageFolder.GetItemsAsync().AsTask().ConfigureAwait(false);
                     foreach (var item in items)
                     {
-                        var itemName = item.Name;
-                        var itemLength = itemName.Length;
-                        var extLength = FileExtension.Length;
-                        if (itemName.EndsWith(FileExtension) && itemLength > extLength)
+                        if (item.Name.EndsWith(FileExtension))
                         {
-                            keys.Add(item.Name.Substring(0, itemLength - extLength));
+                            keys.Add(GetKeyName(item.Name));
                         }
                     }
                 }
@@ -292,14 +311,16 @@ namespace ReactNative.Modules.Storage
 
         private async Task<string> GetAsync(string key)
         {
-            var localFolder = ApplicationData.Current.LocalFolder;
-            var fileName = GetFileName(key);
-
-            var storageItem = await localFolder.TryGetItemAsync(fileName).AsTask().ConfigureAwait(false);
-            if (storageItem != null)
+            var storageFolder = await GetAsyncStorageFolder(false);
+            if (storageFolder != null)
             {
-                var file = await localFolder.GetFileAsync(fileName).AsTask().ConfigureAwait(false);
-                return await FileIO.ReadTextAsync(file).AsTask().ConfigureAwait(false);
+                var fileName = GetFileName(key);
+                var storageItem = await storageFolder.TryGetItemAsync(fileName).AsTask().ConfigureAwait(false);
+                if (storageItem != null)
+                {
+                    var file = await storageFolder.GetFileAsync(fileName).AsTask().ConfigureAwait(false);
+                    return await FileIO.ReadTextAsync(file).AsTask().ConfigureAwait(false);
+                }
             }
 
             return null;
@@ -327,12 +348,15 @@ namespace ReactNative.Modules.Storage
 
         private async Task<JObject> RemoveAsync(string key)
         {
-            var localFolder = ApplicationData.Current.LocalFolder;
-            var fileName = GetFileName(key);
-            var storageItem = await localFolder.TryGetItemAsync(fileName).AsTask().ConfigureAwait(false);
-            if (storageItem != null)
+            var storageFolder = await GetAsyncStorageFolder(false);
+            if (storageFolder != null)
             {
-                await storageItem.DeleteAsync().AsTask().ConfigureAwait(false);
+                var fileName = GetFileName(key);
+                var storageItem = await storageFolder.TryGetItemAsync(fileName).AsTask().ConfigureAwait(false);
+                if (storageItem != null)
+                {
+                    await storageItem.DeleteAsync().AsTask().ConfigureAwait(false);
+                }
             }
 
             return null;
@@ -340,65 +364,105 @@ namespace ReactNative.Modules.Storage
 
         private async Task<JObject> SetAsync(string key, string value)
         {
-            var localFolder = ApplicationData.Current.LocalFolder;
-            var file = await localFolder.CreateFileAsync(GetFileName(key), CreationCollisionOption.ReplaceExisting).AsTask().ConfigureAwait(false);
+            var storageFolder = await GetAsyncStorageFolder(true);
+            var file = await storageFolder.CreateFileAsync(GetFileName(key), CreationCollisionOption.ReplaceExisting).AsTask().ConfigureAwait(false);
             await FileIO.WriteTextAsync(file, value).AsTask().ConfigureAwait(false);
             return default(JObject);
         }
 
+        private static async Task<StorageFolder> GetAsyncStorageFolder(bool createIfNotExists)
+        {
+            if (s_cachedFolder == null)
+            {
+                var localFolder = ApplicationData.Current.LocalFolder;
+                var storageFolderItem = await localFolder.TryGetItemAsync(DirectoryName);
+                s_cachedFolder = storageFolderItem == null && createIfNotExists
+                    ? await localFolder.CreateFolderAsync(DirectoryName, CreationCollisionOption.OpenIfExists)
+                    : null;
+            }
+
+            return s_cachedFolder;
+        }
+
         private static string GetFileName(string key)
         {
-            var sb = new StringBuilder();
-            sb.Append(DirectoryName);
-            foreach (var ch in key)
+            var sb = default(StringBuilder);
+            for (var i = 0; i < key.Length; ++i)
             {
-                switch (ch)
+                var ch = key[i];
+                var replacement = default(string);
+                if (s_charToString.TryGetValue(ch, out replacement))
                 {
-                    case '\\':
-                        sb.Append("{bsl}");
-                        break;
-                    case '/':
-                        sb.Append("{fsl}");
-                        break;
-                    case ':':
-                        sb.Append("{col}");
-                        break;
-                    case '*':
-                        sb.Append("{asx}");
-                        break;
-                    case '?':
-                        sb.Append("{q}");
-                        break;
-                    case '<':
-                        sb.Append("{lt}");
-                        break;
-                    case '>':
-                        sb.Append("{gt}");
-                        break;
-                    case '|':
-                        sb.Append("{bar}");
-                        break;
-                    case '"':
-                        sb.Append("{quo}");
-                        break;
-                    case '.':
-                        sb.Append("{dot}");
-                        break;
-                    case '{':
-                        sb.Append("{ocb}");
-                        break;
-                    case '}':
-                        sb.Append("{ccb}");
-                        break;
-                    default:
-                        sb.Append(ch);
-                        break;
+                    if (sb == null)
+                    {
+                        sb = new StringBuilder();
+                        sb.Append(key, 0, i);
+                    }
+
+                    sb.Append(replacement);
+                }
+                else if (sb != null)
+                {
+                    sb.Append(ch);
+                }
+            }
+            
+            if (sb == null)
+            {
+                return string.Concat(key, FileExtension);
+            }
+            else
+            {
+                sb.Append(FileExtension);
+                return sb.ToString();
+            }
+        }
+
+        private static string GetKeyName(string fileName)
+        {
+            var length = fileName.Length - FileExtension.Length;
+            var sb = default(StringBuilder);
+            for (var i = 0; i < length; ++i)
+            {
+                var start = fileName[i];
+                if (start == '{')
+                {
+                    var j = i;
+                    while (j < fileName.Length && (j - i) < s_maxReplace)
+                    {
+                        var end = fileName[++j];
+                        if (end == '}')
+                        {
+                            break;
+                        }
+                    }
+
+                    if (j < length && (j - i) < s_maxReplace)
+                    {
+                        var substring = fileName.Substring(i, j - i + 1);
+                        var replacement = default(char);
+                        if (s_stringToChar.TryGetValue(substring, out replacement))
+                        {
+                            if (sb == null)
+                            {
+                                sb = new StringBuilder();
+                                sb.Append(fileName, 0, i);
+                            }
+
+                            sb.Append(replacement);
+                            i = j;
+                        }
+                    }
+                }
+                else if (sb != null)
+                {
+                    sb.Append(start);
                 }
             }
 
-            sb.Append(FileExtension);
-
-            return sb.ToString();
+            return sb == null
+                ? fileName.Substring(0, length)
+                : sb.ToString();
         }
 
         private static void DeepMergeInto(JObject oldJson, JObject newJson)


### PR DESCRIPTION
The mapping used from key to filename was not used to convert from filename back to key. Additionally, adds some optimizations to reduce allocations for AsyncStorage.

Fixes #724