### PR TITLE
fix(PasswordBox): Fixes minor bug with keyboard type on PasswordBox

### DIFF
--- a/ReactWindows/ReactNative/Views/TextInput/InputScopeHelpers.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/InputScopeHelpers.cs
@@ -28,5 +28,16 @@ namespace ReactNative.Views.TextInput
                     return InputScopeNameValue.Default;
             }
         }
+
+        public static InputScopeNameValue FromStringForPasswordBox(string inputScope)
+        {
+            switch (inputScope)
+            {
+                case "number-pad":
+                    return InputScopeNameValue.NumericPin;
+                default:
+                    return InputScopeNameValue.Password;
+            }
+        }
     }
 }

--- a/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
@@ -275,12 +275,11 @@ namespace ReactNative.Views.TextInput
         public void SetKeyboardType(PasswordBox view, string keyboardType)
         {
             var inputScope = new InputScope();
-            inputScope.Names.Add(
-                new InputScopeName(
-                    keyboardType != null
-                        ? InputScopeHelpers.FromStringForPasswordBox(keyboardType)
-                        : InputScopeNameValue.Password));
+            var nameValue = keyboardType != null
+                ? InputScopeHelpers.FromStringForPasswordBox(keyboardType)
+                : InputScopeNameValue.Password;
 
+            inputScope.Names.Add(new InputScopeName(nameValue));
             view.InputScope = inputScope;
         }
 

--- a/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
@@ -274,16 +274,14 @@ namespace ReactNative.Views.TextInput
         [ReactProp("keyboardType")]
         public void SetKeyboardType(PasswordBox view, string keyboardType)
         {
-            view.InputScope = null;
-            if (keyboardType != null)
-            {
-                var inputScope = new InputScope();
-                inputScope.Names.Add(
-                    new InputScopeName(
-                        InputScopeHelpers.FromString(keyboardType)));
+            var inputScope = new InputScope();
+            inputScope.Names.Add(
+                new InputScopeName(
+                    keyboardType != null
+                        ? InputScopeHelpers.FromStringForPasswordBox(keyboardType)
+                        : InputScopeNameValue.Password));
 
-                view.InputScope = inputScope;
-            }
+            view.InputScope = inputScope;
         }
 
         /// <summary>


### PR DESCRIPTION
PasswordBox only supports 'number-pad' and 'password' (i.e., InputScopeNameValue.NumericPin and InputScopeNameValue.Password).

Fixes #726