### PR TITLE
fix(TouchHandler): Consider all possible views for click target

### DIFF
--- a/ReactWindows/ReactNative/UIManager/RootViewHelper.cs
+++ b/ReactWindows/ReactNative/UIManager/RootViewHelper.cs
@@ -36,17 +36,11 @@ namespace ReactNative.UIManager
         }
 
         /// <summary>
-        /// Returns the list of pointer events views in the hierarchy, starting
-        /// from the root view.
+        /// Gets the hierarchy of React views from the given view.
         /// </summary>
         /// <param name="view">The view.</param>
-        /// <returns>The pointer events hierarchy.</returns>
-        public static IList<UIElement> GetReactViewHierarchy(DependencyObject view)
-        {
-            return GetReactViewHierarchyCore(view).Reverse().ToList();
-        }
-
-        private static IEnumerable<UIElement> GetReactViewHierarchyCore(DependencyObject view)
+        /// <returns>The view hierarchy.</returns>
+        public static IEnumerable<UIElement> GetReactViewHierarchy(DependencyObject view)
         {
             var current = view;
             while (true)


### PR DESCRIPTION
Previously, we were only considering the hierarchy from the pointer "OriginalSource" in the pointer events calculations. Unfortunately, this meant that if a transparent overlay with "box-none" or "none" pointer events was set, as is the case for "react-native-drawer", then no alternative targets would be considered. This change uses VisualTreeHelper.FindElementsInHostCoordinates to consider all possible targets.

Fixes #715