### PR TITLE
fix(ReactInstance): Set bridge instance before calling LoadScript

### DIFF
--- a/ReactWindows/ReactNative/Bridge/ReactInstance.cs
+++ b/ReactWindows/ReactNative/Bridge/ReactInstance.cs
@@ -120,8 +120,9 @@ namespace ReactNative.Bridge
                     }
 
                     _bundleLoader.LoadScript(_bridge);
+
                     return default(object);
-                });
+                }).ConfigureAwait(false);
             }
         }
 

--- a/ReactWindows/ReactNative/Bridge/ReactInstance.cs
+++ b/ReactWindows/ReactNative/Bridge/ReactInstance.cs
@@ -109,15 +109,19 @@ namespace ReactNative.Bridge
                             QueueConfiguration.NativeModulesQueueThread);
                     }
 
-                    using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "setBatchedBridgeConfig").Start())
-                    {
-                        bridge.SetGlobalVariable("__fbBatchedBridgeConfig", BuildModulesConfig());
-                    }
-
-                    _bundleLoader.LoadScript(bridge);
-
                     return bridge;
                 }).ConfigureAwait(false);
+
+                await QueueConfiguration.JavaScriptQueueThread.CallOnQueue(() =>
+                {
+                    using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "setBatchedBridgeConfig").Start())
+                    {
+                        _bridge.SetGlobalVariable("__fbBatchedBridgeConfig", BuildModulesConfig());
+                    }
+
+                    _bundleLoader.LoadScript(_bridge);
+                    return default(object);
+                });
             }
         }
 


### PR DESCRIPTION
JavaScript may call native behaviors prior to the `_bridge` variable being set in `ReactInstance`, which would be invoked in the initial call to `FlushedQueue` following the call to run the bundle.

This change set ensures the `_bridge` is set before the bundle is loaded.

Fixes #744