### PR TITLE
fix(SplitView): Ensure clicking outside SplitView pane closes the pane

### DIFF
--- a/ReactWindows/ReactNative/UIManager/RootViewHelper.cs
+++ b/ReactWindows/ReactNative/UIManager/RootViewHelper.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 
@@ -40,7 +39,7 @@ namespace ReactNative.UIManager
         /// </summary>
         /// <param name="view">The view.</param>
         /// <returns>The view hierarchy.</returns>
-        public static IEnumerable<UIElement> GetReactViewHierarchy(DependencyObject view)
+        public static IEnumerable<DependencyObject> GetReactViewHierarchy(DependencyObject view)
         {
             var current = view;
             while (true)
@@ -63,6 +62,19 @@ namespace ReactNative.UIManager
 
                 current = GetParent(current, false);
             }
+        }
+
+        /// <summary>
+        /// Checks if the view is part of the React hierarchy.
+        /// </summary>
+        /// <param name="view">The view instance.</param>
+        /// <returns>
+        /// <code>true</code> if the view is part of the hierarchy, otherwise
+        /// <code>false</code>.
+        /// </returns>
+        public static bool IsReactSubview(DependencyObject view)
+        {
+            return GetReactViewHierarchy(view).GetEnumerator().MoveNext();
         }
 
         private static DependencyObject GetParent(DependencyObject view, bool findRoot)


### PR DESCRIPTION
A recent change to the touch handler to support cases where overlays that did not support any pointer events were used (so the underlying React view that did support pointer events could be reached) ignored the fact that some clicks simply don't belong to the React hierarchy (e.g., native app overlays, as is the case for SplitView).

This change first checks that the original pointer target actually belongs to the React before calculating the target using pointer events logic.

Fixes #746