### PR TITLE
Enable Images to have muliple <Text> ancestors

### DIFF
--- a/ReactWindows/ReactNative/Views/Text/ReactSpanViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactSpanViewManager.cs
@@ -59,8 +59,17 @@ namespace ReactNative.Views.Text
         public void AddView(DependencyObject parent, DependencyObject child, int index)
         {
             var span = (Span)parent;
-            var inline = (Inline)child;
-            span.Inlines.Insert(index, inline);
+
+            var inlineChild = child as Inline;
+            if (inlineChild == null)
+            {
+                inlineChild = new InlineUIContainer
+                {
+                    Child = (UIElement)child,
+                };
+            }
+
+            span.Inlines.Insert(index, inlineChild);
         }
 
         /// <summary>
@@ -87,7 +96,16 @@ namespace ReactNative.Views.Text
         public DependencyObject GetChildAt(DependencyObject parent, int index)
         {
             var span = (Span)parent;
-            return span.Inlines[index];
+            var child = span.Inlines[index];
+            var childInlineContainer = child as InlineUIContainer;
+            if (childInlineContainer != null)
+            {
+                return childInlineContainer.Child;
+            }
+            else
+            {
+                return child;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Prior to this change, Images with one <Text> ancestor were supported:

```
<Text>
  <Image />
</Text>
```

But Images with multiple <Text> ancestors resulted in an exception:

```
<Text>
  <Text>
    <Image />
  </Text>
</Text>
```

This change fixes the latter scenario.

The problem was that some code assumed that it would only receive Inlines when actually it could also receive UIElements.