### PR TITLE
fix(FrameDispatch): All operations on Rendering event should catch exceptions

### DIFF
--- a/ReactWindows/ReactNative/Animated/NativeAnimatedModule.cs
+++ b/ReactWindows/ReactNative/Animated/NativeAnimatedModule.cs
@@ -101,30 +101,37 @@ namespace ReactNative.Animated
             var nodesManager = new NativeAnimatedNodesManager(uiImpl);
             _animatedFrameCallback = (sender, args) =>
             {
-                var renderingArgs = args as RenderingEventArgs;
-                if (renderingArgs == null)
+                try
                 {
-                    return;
-                }
-
-                var operations = default(List<Action<NativeAnimatedNodesManager>>);
-                lock (_operationsGate)
-                {
-                    operations = _readyOperations;
-                    _readyOperations = null;
-                }
-
-                if (operations != null)
-                {
-                    foreach (var operation in operations)
+                    var renderingArgs = args as RenderingEventArgs;
+                    if (renderingArgs == null)
                     {
-                        operation(nodesManager);
+                        return;
+                    }
+
+                    var operations = default(List<Action<NativeAnimatedNodesManager>>);
+                    lock (_operationsGate)
+                    {
+                        operations = _readyOperations;
+                        _readyOperations = null;
+                    }
+
+                    if (operations != null)
+                    {
+                        foreach (var operation in operations)
+                        {
+                            operation(nodesManager);
+                        }
+                    }
+
+                    if (nodesManager.HasActiveAnimations)
+                    {
+                        nodesManager.RunUpdates(renderingArgs.RenderingTime);
                     }
                 }
-
-                if (nodesManager.HasActiveAnimations)
+                catch (Exception ex)
                 {
-                    nodesManager.RunUpdates(renderingArgs.RenderingTime);
+                    Context.HandleException(ex);
                 }
             };
 

--- a/ReactWindows/ReactNative/Modules/Core/Timing.cs
+++ b/ReactWindows/ReactNative/Modules/Core/Timing.cs
@@ -60,7 +60,7 @@ namespace ReactNative.Modules.Core
             _suspended = true;
             if (_renderingHandled)
             {
-                CompositionTarget.Rendering -= DoFrame;
+                CompositionTarget.Rendering -= DoFrameSafe;
                 _renderingHandled = false;
             }
         }
@@ -73,7 +73,7 @@ namespace ReactNative.Modules.Core
             _suspended = false;
             if (!_renderingHandled)
             {
-                CompositionTarget.Rendering += DoFrame;
+                CompositionTarget.Rendering += DoFrameSafe;
                 _renderingHandled = true;
             }
         }
@@ -85,7 +85,7 @@ namespace ReactNative.Modules.Core
         {
             if (_renderingHandled)
             {
-                CompositionTarget.Rendering -= DoFrame;
+                CompositionTarget.Rendering -= DoFrameSafe;
                 _renderingHandled = false;
             }
         }
@@ -135,6 +135,18 @@ namespace ReactNative.Modules.Core
             lock (_gate)
             {
                 _timers.Remove(new TimerData(timerId));
+            }
+        }
+
+        private void DoFrameSafe(object sender, object e)
+        {
+            try
+            {
+                DoFrame(sender, e);
+            }
+            catch (Exception ex)
+            {
+                Context.HandleException(ex);
             }
         }
 

--- a/ReactWindows/ReactNative/UIManager/Events/EventDispatcher.cs
+++ b/ReactWindows/ReactNative/UIManager/Events/EventDispatcher.cs
@@ -243,6 +243,18 @@ namespace ReactNative.UIManager.Events
                 (((long)coalescingKey) & 0xffff) << 48;
         }
 
+        private void ScheduleDispatcherSafe(object sender, object e)
+        {
+            try
+            {
+                ScheduleDispatch(sender, e);
+            }
+            catch (Exception ex)
+            {
+                _reactContext.HandleException(ex);
+            }
+        }
+
         private void ScheduleDispatch(object sender, object e)
         {
             DispatcherHelpers.AssertOnDispatcher();

--- a/ReactWindows/ReactNative/UIManager/Events/EventDispatcher.cs
+++ b/ReactWindows/ReactNative/UIManager/Events/EventDispatcher.cs
@@ -129,7 +129,7 @@ namespace ReactNative.UIManager.Events
                 _rctEventEmitter = _reactContext.GetJavaScriptModule<RCTEventEmitter>();
             }
 
-            CompositionTarget.Rendering += ScheduleDispatch;
+            CompositionTarget.Rendering += ScheduleDispatcherSafe;
         }
 
         /// <summary>
@@ -159,7 +159,7 @@ namespace ReactNative.UIManager.Events
         private void ClearCallback()
         {
             DispatcherHelpers.AssertOnDispatcher();
-            CompositionTarget.Rendering -= ScheduleDispatch;
+            CompositionTarget.Rendering -= ScheduleDispatcherSafe;
         }
 
         private void MoveStagedEventsToDispatchQueue()


### PR DESCRIPTION
Previously, failures on the CompositionTarget.Rendering event could crash the app. With these changes, each frame callback has an exception handling wrapper.

Fixes #750