### PR TITLE
fix(Image): view.Background.ImageSource is not always valid OnLoad

### DIFF
--- a/ReactWindows/ReactNative/Modules/Image/BitmapImageHelpers.cs
+++ b/ReactWindows/ReactNative/Modules/Image/BitmapImageHelpers.cs
@@ -49,14 +49,14 @@ namespace ReactNative.Modules.Image
             }
         }
 
-        public static IObservable<ImageLoadStatus> GetStreamLoadObservable(this BitmapImage image)
+        public static IObservable<ImageStatusEventData> GetStreamLoadObservable(this BitmapImage image)
         {
             return image.GetOpenedObservable()
                 .Merge(image.GetFailedObservable(), Scheduler.Default)
-                .StartWith(ImageLoadStatus.OnLoadStart);
+                .StartWith(new ImageStatusEventData(ImageLoadStatus.OnLoadStart));
         }
 
-        public static IObservable<ImageLoadStatus> GetUriLoadObservable(this BitmapImage image)
+        public static IObservable<ImageStatusEventData> GetUriLoadObservable(this BitmapImage image)
         {
             return Observable.Merge(
                 Scheduler.Default,
@@ -65,34 +65,50 @@ namespace ReactNative.Modules.Image
                 image.GetFailedObservable());
         }
 
-        private static IObservable<ImageLoadStatus> GetOpenedObservable(this BitmapImage image)
+        private static IObservable<ImageStatusEventData> GetOpenedObservable(this BitmapImage image)
         {
             return Observable.FromEventPattern<RoutedEventHandler, RoutedEventArgs>(
                 h => image.ImageOpened += h,
                 h => image.ImageOpened -= h)
-                .Select(_ => ImageLoadStatus.OnLoad)
+                .Select(args =>
+                {
+                    var bitmapImage = args.Sender as BitmapImage;
+                    if (bitmapImage != null)
+                    {
+                        return new ImageStatusEventData(
+                            ImageLoadStatus.OnLoad,
+                            new ImageMetadata(
+                                image.UriSource?.AbsoluteUri,
+                                image.PixelWidth,
+                                image.PixelHeight));
+                    }
+                    else
+                    {
+                        return new ImageStatusEventData(ImageLoadStatus.OnLoad);
+                    }
+                })
                 .Take(1)
-                .Concat(Observable.Return(ImageLoadStatus.OnLoadEnd));
+                .Concat(Observable.Return(new ImageStatusEventData(ImageLoadStatus.OnLoadEnd)));
         }
 
-        private static IObservable<ImageLoadStatus> GetFailedObservable(this BitmapImage image)
+        private static IObservable<ImageStatusEventData> GetFailedObservable(this BitmapImage image)
         {
             return Observable.FromEventPattern<ExceptionRoutedEventHandler, ExceptionRoutedEventArgs>(
                 h => image.ImageFailed += h,
                 h => image.ImageFailed -= h)
-                .Select<EventPattern<ExceptionRoutedEventArgs>, ImageLoadStatus>(pattern =>
+                .Select<EventPattern<ExceptionRoutedEventArgs>, ImageStatusEventData>(pattern =>
                 {
                     throw new InvalidOperationException(pattern.EventArgs.ErrorMessage);
                 });
         }
 
-        private static IObservable<ImageLoadStatus> GetDownloadingObservable(this BitmapImage image)
+        private static IObservable<ImageStatusEventData> GetDownloadingObservable(this BitmapImage image)
         {
             return Observable.FromEventPattern<DownloadProgressEventHandler, DownloadProgressEventArgs>(
                 h => image.DownloadProgress += h,
                 h => image.DownloadProgress -= h)
                 .Take(1)
-                .Select(_ => ImageLoadStatus.OnLoadStart);
+                .Select(_ => new ImageStatusEventData(ImageLoadStatus.OnLoadStart));
         }
     }
 }

--- a/ReactWindows/ReactNative/Modules/Image/ImageLoaderModule.cs
+++ b/ReactWindows/ReactNative/Modules/Image/ImageLoaderModule.cs
@@ -41,7 +41,7 @@ namespace ReactNative.Modules.Image
                 {
                     var bitmapImage = new BitmapImage();
                     var loadQuery = bitmapImage.GetStreamLoadObservable()
-                        .Where(status => status == ImageLoadStatus.OnLoadEnd)
+                        .Where(status => status.LoadStatus == ImageLoadStatus.OnLoadEnd)
                         .FirstAsync()
                         .Replay(1);
 

--- a/ReactWindows/ReactNative/Modules/Image/ImageMetadata.cs
+++ b/ReactWindows/ReactNative/Modules/Image/ImageMetadata.cs
@@ -1,0 +1,18 @@
+﻿namespace ReactNative.Modules.Image
+{
+    struct ImageMetadata
+    {
+        public ImageMetadata(string uri, int width, int height)
+        {
+            Uri = uri;
+            Width = width;
+            Height = height;
+        }
+
+        public string Uri { get; }
+
+        public int Width { get; }
+
+        public int Height { get; }
+    }
+}

--- a/ReactWindows/ReactNative/Modules/Image/ImageStatusEventData.cs
+++ b/ReactWindows/ReactNative/Modules/Image/ImageStatusEventData.cs
@@ -1,0 +1,20 @@
+﻿namespace ReactNative.Modules.Image
+{
+    struct ImageStatusEventData
+    {
+        public ImageStatusEventData(ImageLoadStatus loadStatus)
+            : this(loadStatus, default(ImageMetadata))
+        {
+        }
+
+        public ImageStatusEventData(ImageLoadStatus loadStatus, ImageMetadata metadata)
+        {
+            LoadStatus = loadStatus;
+            Metadata = metadata;
+        }
+
+        public ImageLoadStatus LoadStatus { get; }
+
+        public ImageMetadata Metadata { get; }
+    }
+}

--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -154,6 +154,8 @@
     <Compile Include="Modules\I18N\I18NModule.cs" />
     <Compile Include="Modules\I18N\I18NUtil.cs" />
     <Compile Include="Modules\Image\ImageLoadStatus.cs" />
+    <Compile Include="Modules\Image\ImageMetadata.cs" />
+    <Compile Include="Modules\Image\ImageStatusEventData.cs" />
     <Compile Include="Modules\Launch\LauncherModule.cs" />
     <Compile Include="Modules\Location\LocationModule.cs" />
     <Compile Include="Modules\NetInfo\DefaultNetworkInformation.cs" />

--- a/ReactWindows/ReactNative/Views/Image/ReactImageManager.cs
+++ b/ReactWindows/ReactNative/Views/Image/ReactImageManager.cs
@@ -253,35 +253,19 @@ namespace ReactNative.Views.Image
                         ReactImageLoadEvent.OnLoadEnd));
         }
 
-        private void OnImageStatusUpdate(Border view, ImageLoadStatus status)
+        private void OnImageStatusUpdate(Border view, ImageStatusEventData status)
         {
             var eventDispatcher = view.GetReactContext()
                 .GetNativeModule<UIManagerModule>()
                 .EventDispatcher;
 
-            if (status == ImageLoadStatus.OnLoad)
-            {
-                var bitmapImage = GetBitmapImage(view);
-                eventDispatcher.DispatchEvent(
-                    new ReactImageLoadEvent(
-                        view.GetTag(),
-                        (int)status,
-                        bitmapImage.UriSource.AbsolutePath,
-                        bitmapImage.PixelWidth,
-                        bitmapImage.PixelHeight));
-            }
-            else
-            {
-                eventDispatcher.DispatchEvent(
-                    new ReactImageLoadEvent(
-                        view.GetTag(),
-                        (int)status));
-            }
-        }
-
-        private BitmapImage GetBitmapImage(Border view)
-        {
-            return (BitmapImage)((ImageBrush)view.Background).ImageSource;
+            eventDispatcher.DispatchEvent(
+                new ReactImageLoadEvent(
+                    view.GetTag(),
+                    (int)status.LoadStatus,
+                    status.Metadata.Uri,
+                    status.Metadata.Width,
+                    status.Metadata.Height));
         }
 
         /// <summary>


### PR DESCRIPTION
Getting null reference exceptions due to a condition where the ImageSource is not always set on the ImageBrush.  Instead, gathering the image metadata directly from the OnLoad event.