### PR TITLE
fix(Chakra): Throw less cryptic error message for invalid bundle

### DIFF
--- a/ReactWindows/ReactNative/Chakra/Executor/ChakraJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/Chakra/Executor/ChakraJavaScriptExecutor.cs
@@ -410,7 +410,7 @@ namespace ReactNative.Chakra.Executor
             if (fbBatchedBridge.ValueType != JavaScriptValueType.Object)
             {
                 throw new InvalidOperationException(
-                    Invariant($"Could not resolve '{FBBatchedBridgeVariableName}' instance.  Check the JavaScript bundle to ensure it is generated correctly."));
+                    Invariant($"Could not resolve '{FBBatchedBridgeVariableName}' object.  Check the JavaScript bundle to ensure it is generated correctly."));
             }
 
             return fbBatchedBridge;

--- a/ReactWindows/ReactNative/Chakra/Executor/ChakraJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/Chakra/Executor/ChakraJavaScriptExecutor.cs
@@ -402,6 +402,20 @@ namespace ReactNative.Chakra.Executor
             return _parseFunction;
         }
 
+        private JavaScriptValue EnsureBatchedBridge()
+        {
+            var globalObject = EnsureGlobalObject();
+            var propertyId = JavaScriptPropertyId.FromString(FBBatchedBridgeVariableName);
+            var fbBatchedBridge = globalObject.GetProperty(propertyId);
+            if (fbBatchedBridge.ValueType != JavaScriptValueType.Object)
+            {
+                throw new InvalidOperationException(
+                    Invariant($"Could not resolve '{FBBatchedBridgeVariableName}' instance.  Check the JavaScript bundle to ensure it is generated correctly."));
+            }
+
+            return fbBatchedBridge;
+        }
+
         private JavaScriptValue EnsureStringifyFunction()
         {
             if (!_stringifyFunction.IsValid)
@@ -418,9 +432,7 @@ namespace ReactNative.Chakra.Executor
         {
             if (!_callFunctionAndReturnFlushedQueueFunction.IsValid)
             {
-                var globalObject = EnsureGlobalObject();
-                var propertyId = JavaScriptPropertyId.FromString(FBBatchedBridgeVariableName);
-                var fbBatchedBridge = globalObject.GetProperty(propertyId);
+                var fbBatchedBridge = EnsureBatchedBridge();
                 var functionPropertyId = JavaScriptPropertyId.FromString("callFunctionReturnFlushedQueue");
                 _callFunctionAndReturnFlushedQueueFunction = fbBatchedBridge.GetProperty(functionPropertyId);
             }
@@ -432,9 +444,7 @@ namespace ReactNative.Chakra.Executor
         {
             if (!_invokeCallbackAndReturnFlushedQueueFunction.IsValid)
             {
-                var globalObject = EnsureGlobalObject();
-                var propertyId = JavaScriptPropertyId.FromString(FBBatchedBridgeVariableName);
-                var fbBatchedBridge = globalObject.GetProperty(propertyId);
+                var fbBatchedBridge = EnsureBatchedBridge();
                 var functionPropertyId = JavaScriptPropertyId.FromString("invokeCallbackAndReturnFlushedQueue");
                 _invokeCallbackAndReturnFlushedQueueFunction = fbBatchedBridge.GetProperty(functionPropertyId);
             }
@@ -446,9 +456,7 @@ namespace ReactNative.Chakra.Executor
         {
             if (!_flushedQueueFunction.IsValid)
             {
-                var globalObject = EnsureGlobalObject();
-                var propertyId = JavaScriptPropertyId.FromString(FBBatchedBridgeVariableName);
-                var fbBatchedBridge = globalObject.GetProperty(propertyId);
+                var fbBatchedBridge = EnsureBatchedBridge();
                 var functionPropertyId = JavaScriptPropertyId.FromString("flushedQueue");
                 _flushedQueueFunction = fbBatchedBridge.GetProperty(functionPropertyId);
             }


### PR DESCRIPTION
Currently, when a bundle has not been created properly using the `react-native bundle` command, an exception along the lines of 'Argument can not be null' is thrown. Now we have a more specific error message along the lines of "Cannot resolve '__fbBatchedBridge' ...".

Fixes #719