### PR TITLE
feat(TouchHandler): Add pointerType to event data

### DIFF
--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -163,6 +163,7 @@
     <Compile Include="ReactPage.cs" />
     <Compile Include="ReactRootView.cs" />
     <Compile Include="Touch\IOnInterceptTouchEventListener.cs" />
+    <Compile Include="Touch\PointerDeviceTypeExtensions.cs" />
     <Compile Include="Touch\TouchHandler.cs" />
     <Compile Include="Tracing\LoggingActivityBuilder.cs" />
     <Compile Include="Tracing\LoggingActivityBuilderExtensions.generated.cs">

--- a/ReactWindows/ReactNative/Touch/PointerDeviceTypeExtensions.cs
+++ b/ReactWindows/ReactNative/Touch/PointerDeviceTypeExtensions.cs
@@ -1,0 +1,22 @@
+﻿using Windows.Devices.Input;
+
+namespace ReactNative.Touch
+{
+    static class PointerDeviceTypeExtensions
+    {
+        public static string GetPointerDeviceTypeName(this PointerDeviceType pointerDeviceType)
+        {
+            switch (pointerDeviceType)
+            {
+                case PointerDeviceType.Touch:
+                    return "touch";
+                case PointerDeviceType.Pen:
+                    return "pen";
+                case PointerDeviceType.Mouse:
+                    return "mouse";
+                default:
+                    return "unknown";
+            }
+        }
+    }
+}

--- a/ReactWindows/ReactNative/Touch/TouchHandler.cs
+++ b/ReactWindows/ReactNative/Touch/TouchHandler.cs
@@ -53,20 +53,20 @@ namespace ReactNative.Touch
             var reactView = GetReactViewTarget(originalSource, rootPoint.Position);
             if (reactView != null && _view.CapturePointer(e.Pointer))
             {
-                var pointerPoint = e.GetCurrentPoint(reactView);
-                var reactTag = reactView.GetReactCompoundView().GetReactTagAtPoint(reactView, pointerPoint.Position);
+                var viewPoint = e.GetCurrentPoint(reactView);
+                var reactTag = reactView.GetReactCompoundView().GetReactTagAtPoint(reactView, viewPoint.Position);
                 var pointer = new ReactPointer();
                 pointer.Target = reactTag;
                 pointer.PointerId = e.Pointer.PointerId;
                 pointer.Identifier = ++_pointerIDs;
                 pointer.PointerType = e.Pointer.PointerDeviceType.GetPointerDeviceTypeName();
-                pointer.IsLeftButton = pointerPoint.Properties.IsLeftButtonPressed;
-                pointer.IsRightButton = pointerPoint.Properties.IsRightButtonPressed;
-                pointer.IsMiddleButton = pointerPoint.Properties.IsMiddleButtonPressed;
-                pointer.IsHorizontalMouseWheel = pointerPoint.Properties.IsHorizontalMouseWheel;
-                pointer.IsEraser = pointerPoint.Properties.IsEraser;
+                pointer.IsLeftButton = viewPoint.Properties.IsLeftButtonPressed;
+                pointer.IsRightButton = viewPoint.Properties.IsRightButtonPressed;
+                pointer.IsMiddleButton = viewPoint.Properties.IsMiddleButtonPressed;
+                pointer.IsHorizontalMouseWheel = viewPoint.Properties.IsHorizontalMouseWheel;
+                pointer.IsEraser = viewPoint.Properties.IsEraser;
                 pointer.ReactView = reactView;
-                UpdatePointerForEvent(pointer, rootPoint, pointerPoint);
+                UpdatePointerForEvent(pointer, rootPoint, viewPoint);
 
                 var pointerIndex = _pointers.Count;
                 _pointers.Add(pointer);

--- a/ReactWindows/ReactNative/Touch/TouchHandler.cs
+++ b/ReactWindows/ReactNative/Touch/TouchHandler.cs
@@ -23,6 +23,7 @@ namespace ReactNative.Touch
             _pointers = new List<ReactPointer>();
 
             _view.PointerPressed += OnPointerPressed;
+            _view.RightTapped += OnRightPointerPressed;
             _view.PointerMoved += OnPointerMoved;
             _view.PointerReleased += OnPointerReleased;
             _view.PointerCanceled += OnPointerCanceled;
@@ -32,6 +33,7 @@ namespace ReactNative.Touch
         public void Dispose()
         {
             _view.PointerPressed -= OnPointerPressed;
+            _view.RightTapped -= OnRightPointerPressed;
             _view.PointerMoved -= OnPointerMoved;
             _view.PointerReleased -= OnPointerReleased;
             _view.PointerCanceled -= OnPointerCanceled;
@@ -54,6 +56,7 @@ namespace ReactNative.Touch
                 var pointer = new ReactPointer();
                 pointer.Target = reactTag;
                 pointer.PointerId = e.Pointer.PointerId;
+                pointer.PointerType = e.Pointer.PointerDeviceType.GetPointerDeviceTypeName();
                 pointer.Identifier = ++_pointerIDs;
                 pointer.ReactView = reactView;
                 UpdatePointerForEvent(pointer, e);
@@ -62,6 +65,11 @@ namespace ReactNative.Touch
                 _pointers.Add(pointer);
                 DispatchTouchEvent(TouchEventType.Start, _pointers, pointerIndex);
             }
+        }
+
+        private void OnRightPointerPressed(object sender, RightTappedRoutedEventArgs e)
+        {
+            e.Handled = false;
         }
 
         private void OnPointerMoved(object sender, PointerRoutedEventArgs e)
@@ -312,6 +320,9 @@ namespace ReactNative.Touch
 
             [JsonProperty(PropertyName = "pageY")]
             public float PageY { get; set; }
+
+            [JsonProperty(PropertyName = "pointerType")]
+            public string PointerType { get; set; }
         }
     }
 }

--- a/ReactWindows/ReactNative/Touch/TouchHandler.cs
+++ b/ReactWindows/ReactNative/Touch/TouchHandler.cs
@@ -23,7 +23,6 @@ namespace ReactNative.Touch
             _pointers = new List<ReactPointer>();
 
             _view.PointerPressed += OnPointerPressed;
-            _view.RightTapped += OnRightPointerPressed;
             _view.PointerMoved += OnPointerMoved;
             _view.PointerReleased += OnPointerReleased;
             _view.PointerCanceled += OnPointerCanceled;
@@ -33,7 +32,6 @@ namespace ReactNative.Touch
         public void Dispose()
         {
             _view.PointerPressed -= OnPointerPressed;
-            _view.RightTapped -= OnRightPointerPressed;
             _view.PointerMoved -= OnPointerMoved;
             _view.PointerReleased -= OnPointerReleased;
             _view.PointerCanceled -= OnPointerCanceled;
@@ -65,11 +63,6 @@ namespace ReactNative.Touch
                 _pointers.Add(pointer);
                 DispatchTouchEvent(TouchEventType.Start, _pointers, pointerIndex);
             }
-        }
-
-        private void OnRightPointerPressed(object sender, RightTappedRoutedEventArgs e)
-        {
-            e.Handled = false;
         }
 
         private void OnPointerMoved(object sender, PointerRoutedEventArgs e)


### PR DESCRIPTION
Adds a pointerType field to the native event for the gesture responder handlers. Basically, e.nativeEvent.pointerType is oneOf ["mouse", "pen", "touch"].  I'll need to follow up with documentation and examples for this.

Fixes #772