### PR TITLE
Allow testID to be set to null

### DIFF
--- a/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
+++ b/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
@@ -120,7 +120,7 @@ namespace ReactNative.UIManager
         [ReactProp("testID")]
         public void SetTestId(TFrameworkElement view, string testId)
         {
-            AutomationProperties.SetAutomationId(view, testId);
+            AutomationProperties.SetAutomationId(view, testId ?? "");
         }
 
         private static void SetProjectionMatrix(TFrameworkElement view, JArray transforms)


### PR DESCRIPTION
passing null as testID works well on  iOS so it will be good to support it on Windows instead of just crashing the app