### PR TITLE
fix(CLI): Add better error handling for react-native-windows generator CLI

### DIFF
--- a/local-cli/rnpm/windows/package.json
+++ b/local-cli/rnpm/windows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rnpm-plugin-windows",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "rnpm plugin that generates a Windows template project",
   "main": "index.js",
   "scripts": {
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "semver": "^5.0.3",
-    "chalk": "^1.1.3"
+    "chalk": "^1.1.3",
+    "node-fetch": "^1.3.3"
   }
 }

--- a/local-cli/rnpm/windows/src/windows.js
+++ b/local-cli/rnpm/windows/src/windows.js
@@ -14,6 +14,7 @@ const execSync = require('child_process').execSync;
 const fs = require('fs');
 const path = require('path');
 const semver = require('semver');
+const fetch = require('node-fetch');
 
 const REACT_NATIVE_WINDOWS_GENERATE_PATH = function() {
   return path.resolve(
@@ -34,6 +35,27 @@ const REACT_NATIVE_PACKAGE_JSON_PATH = function() {
   );
 };
 
+function getLatestPackage() {
+  return fetch('https://registry.npmjs.org/react-native-windows?version=latest')
+    .then(result => result && result.ok && result.json());
+}
+
+function checkPackageExists(version) {
+  return fetch(`https://registry.npmjs.org/react-native-windows?version=${version}`)
+    .then(result =>
+    {
+      if (result && result.ok) {
+        return result.json().then(pkg => pkg.version);
+      } else {
+        return getLatestPackage().then(latest => {
+          throw new Error(`Could not find react-native-windows@${version}. ` +
+            `Latest version of react-native-windows is ${latest.version}, try switching to ` +
+            `react-native@${semver.major(latest.version)}.${semver.minor(latest.version)}.*.`);
+        });          
+      }
+    });
+}
+
 function getInstallPackage(version) {
   let packageToInstall = 'react-native-windows';
 
@@ -47,15 +69,13 @@ function getInstallPackage(version) {
     process.exit(1);
   }
 
-  if (validVersion) {
-    packageToInstall += '@' + validVersion;
-  } else if (validRange) {
-    packageToInstall += '@' + version;
-  } else if (version) {
-    // for tar.gz or alternative paths
-    packageToInstall = version;
+  const validVersionOrRange = validVersion || validRange;
+  if (validVersionOrRange) {
+    return checkPackageExists(validVersionOrRange)
+      .then(resultVersion => packageToInstall + '@' + resultVersion);
+  } else {
+    return Promise.resolve(version);
   }
-  return packageToInstall;
 }
 
 function getReactNativeVersion() {
@@ -70,11 +90,15 @@ module.exports = function windows(config, args, options) {
   const ns = options.namespace ? options.namespace : name;
   const version = options.windowsVersion ? options.windowsVersion : getReactNativeVersion();
 
-  const rnwPackage = getInstallPackage(version);
-  console.log(chalk.green(`Installing ${rnwPackage}...`));
-  execSync(`npm install --save ${rnwPackage}`);
-  console.log(chalk.green(`${rnwPackage} successfully installed.`));
+  return getInstallPackage(version)
+    .then(rnwPackage =>
+    {
+      console.log(chalk.green(`Installing ${rnwPackage}...`));
+      execSync(`npm install --save ${rnwPackage}`);
+      console.log(chalk.green(`${rnwPackage} successfully installed.`));
 
-  const generateWindows = require(REACT_NATIVE_WINDOWS_GENERATE_PATH());
-  generateWindows(process.cwd(), name, ns);
-};
+      const generateWindows = require(REACT_NATIVE_WINDOWS_GENERATE_PATH());
+      generateWindows(process.cwd(), name, ns);
+    })
+    .catch(error => console.error(error.message));
+}

--- a/local-cli/rnpm/windows/src/windows.js
+++ b/local-cli/rnpm/windows/src/windows.js
@@ -35,9 +35,10 @@ const REACT_NATIVE_PACKAGE_JSON_PATH = function() {
   );
 };
 
-function getLatestPackage() {
+function getLatestVersion() {
   return fetch('https://registry.npmjs.org/react-native-windows?version=latest')
-    .then(result => result && result.ok && result.json());
+    .then(result => result && result.ok && result.json())
+    .then(result => result.version)
 }
 
 function checkPackageExists(version) {
@@ -47,10 +48,10 @@ function checkPackageExists(version) {
       if (result && result.ok) {
         return result.json().then(pkg => pkg.version);
       } else {
-        return getLatestPackage().then(latest => {
+        return getLatestPackage().then(latestVersion => {
           throw new Error(`Could not find react-native-windows@${version}. ` +
-            `Latest version of react-native-windows is ${latest.version}, try switching to ` +
-            `react-native@${semver.major(latest.version)}.${semver.minor(latest.version)}.*.`);
+            `Latest version of react-native-windows is ${latestVersion}, try switching to ` +
+            `react-native@${semver.major(latestVersion)}.${semver.minor(latestVersion)}.*.`);
         });          
       }
     });
@@ -91,14 +92,12 @@ module.exports = function windows(config, args, options) {
   const version = options.windowsVersion ? options.windowsVersion : getReactNativeVersion();
 
   return getInstallPackage(version)
-    .then(rnwPackage =>
-    {
+    .then(rnwPackage => {
       console.log(chalk.green(`Installing ${rnwPackage}...`));
       execSync(`npm install --save ${rnwPackage}`);
       console.log(chalk.green(`${rnwPackage} successfully installed.`));
 
       const generateWindows = require(REACT_NATIVE_WINDOWS_GENERATE_PATH());
       generateWindows(process.cwd(), name, ns);
-    })
-    .catch(error => console.error(error.message));
+    }).catch(error => console.error(error.message));
 }


### PR DESCRIPTION
Previously, when a version of react-native-windows that matched react-native was not available, a somewhat cryptic dump of all available react-native-windows versions was displayed.  Now, we give a specific message suggesting the version could not be found, what the latest version of react-native-windows is, and a suggestion to upgrade/downgrade to the react-native version that matches.

Fixes #778