### PR TITLE
fix(CLI): Adding transparency to generator script

### DIFF
--- a/local-cli/rnpm/windows/package.json
+++ b/local-cli/rnpm/windows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rnpm-plugin-windows",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "rnpm plugin that generates a Windows template project",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adding some console logging to the generator script to make it clear where the app name and version for react-native-windows.