### PR TITLE
chore(NPM): Add rnpm-plugin-windows code to .npmignore

### DIFF
--- a/local-cli/.npmignore
+++ b/local-cli/.npmignore
@@ -1,0 +1,2 @@
+# Make we do not publish the rnpm folder
+rnpm/


### PR DESCRIPTION
The rnpm-plugin-windows module can potentially exist in two places (it can be picked up by node-haste and generates a warning about the existence of multiple modules with the same name).