### PR TITLE
perf(ReactBridge): Minor improvement to batch processing perf

### DIFF
--- a/ReactWindows/ReactNative/Bridge/ReactBridge.cs
+++ b/ReactWindows/ReactNative/Bridge/ReactBridge.cs
@@ -111,8 +111,8 @@ namespace ReactNative.Bridge
                 return;
             }
 
-            var moduleIds = (JArray)messages[0];
-            var methodIds = (JArray)messages[1];
+            var moduleIds = messages[0] as JArray;
+            var methodIds = messages[1] as JArray;
             var paramsArray = messages[2] as JArray;
             if (moduleIds == null || methodIds == null || paramsArray == null ||
                 moduleIds.Count != methodIds.Count || moduleIds.Count != paramsArray.Count)

--- a/ReactWindows/ReactNative/Bridge/ReactBridge.cs
+++ b/ReactWindows/ReactNative/Bridge/ReactBridge.cs
@@ -111,21 +111,21 @@ namespace ReactNative.Bridge
                 return;
             }
 
-            var moduleIds = messages[0].ToObject<int[]>();
-            var methodIds = messages[1].ToObject<int[]>();
+            var moduleIds = (JArray)messages[0];
+            var methodIds = (JArray)messages[1];
             var paramsArray = messages[2] as JArray;
             if (moduleIds == null || methodIds == null || paramsArray == null ||
-                moduleIds.Length != methodIds.Length || moduleIds.Length != paramsArray.Count)
+                moduleIds.Count != methodIds.Count || moduleIds.Count != paramsArray.Count)
             {
                 throw new InvalidOperationException("Unexpected React batch response.");
             }
 
             _nativeModulesQueueThread.RunOnQueue(() =>
             {
-                for (var i = 0; i < moduleIds.Length; ++i)
+                for (var i = 0; i < moduleIds.Count; ++i)
                 {
-                    var moduleId = moduleIds[i];
-                    var methodId = methodIds[i];
+                    var moduleId = moduleIds[i].Value<int>();
+                    var methodId = methodIds[i].Value<int>();
                     var args = (JArray)paramsArray[i];
 
                     _reactCallback.Invoke(moduleId, methodId, args);
@@ -134,5 +134,7 @@ namespace ReactNative.Bridge
                 _reactCallback.OnBatchComplete();
             });
         }
+
+
     }
 }

--- a/ReactWindows/ReactNative/Bridge/ReactBridge.cs
+++ b/ReactWindows/ReactNative/Bridge/ReactBridge.cs
@@ -3,6 +3,7 @@ using ReactNative.Bridge.Queue;
 using ReactNative.Common;
 using ReactNative.Tracing;
 using System;
+using static System.FormattableString;
 
 namespace ReactNative.Bridge
 {
@@ -107,8 +108,14 @@ namespace ReactNative.Bridge
             var messages = response as JArray;
             if (messages == null)
             {
-                Tracer.Write(ReactConstants.Tag, "Empty JavaScript Queue");
-                return;
+                throw new InvalidOperationException(
+                    "Did not get valid calls back from JavaScript. Message type: " + response.Type);
+            }
+
+            if (messages.Count < 3)
+            {
+                throw new InvalidOperationException(
+                    "Did not get valid calls back from JavaScript. Message count: " + messages.Count);
             }
 
             var moduleIds = messages[0] as JArray;
@@ -117,7 +124,8 @@ namespace ReactNative.Bridge
             if (moduleIds == null || methodIds == null || paramsArray == null ||
                 moduleIds.Count != methodIds.Count || moduleIds.Count != paramsArray.Count)
             {
-                throw new InvalidOperationException("Unexpected React batch response.");
+                throw new InvalidOperationException(
+                    "Did not get valid calls back from JavaScript. JSON: " + response);
             }
 
             _nativeModulesQueueThread.RunOnQueue(() =>
@@ -134,7 +142,5 @@ namespace ReactNative.Bridge
                 _reactCallback.OnBatchComplete();
             });
         }
-
-
     }
 }


### PR DESCRIPTION
Previously, the batch processing step converted the entire list of module IDs and method IDs from the flushed queue into arrays. This involved the allocation of an array. This approach only requires the conversion from a Newtonsoft.Json number (I suspect the internal representation is double) to an integer.

I ran a small test script in a ConsoleApp to ensure this was actually a performance improvement:
```c#
var size = 100;
var repeat = 1000;
var values = Enumerable.Range(0, size);
var json = $"[[{string.Join(",",values)}],[{string.Join(",",values)}],[{string.Join(",", values.Select(_ => "[]"))}]]";
var jarr = JArray.Parse(json);

var x = 0;

GC.Collect();
GC.WaitForPendingFinalizers();

var sw = Stopwatch.StartNew();
for (var i = 0; i < repeat; ++i)
{
    var moduleIds = jarr[0].ToObject<int[]>();
    var methodIds = jarr[1].ToObject<int[]>();
    var arguments = (JArray)jarr[2];
    for (var j = 0; j < moduleIds.Length; ++j)
    {
        var moduleId = moduleIds[j];
        var methodId = methodIds[j];
        var argInst = (JArray)arguments[j];
        Call(moduleId, methodId, argInst);
    }
}
Console.WriteLine("Elapsed: {0} ms", sw.Elapsed.TotalMilliseconds);

GC.Collect();
GC.WaitForPendingFinalizers();

sw.Restart();
for (var i = 0; i < repeat; ++i)
{
    var moduleIds = (JArray)jarr[0];
    var methodIds = (JArray)jarr[1];
    var arguments = (JArray)jarr[2];
    for (var j = 0; j < moduleIds.Count; ++j)
    {
        var moduleId = moduleIds[j].Value<int>();
        var methodId = methodIds[j].Value<int>();
        var argInst = (JArray)arguments[j];
        Call(moduleId, methodId, argInst);
    }
}
Console.WriteLine("Elapsed: {0} ms", sw.Elapsed.TotalMilliseconds);

```

In this case, `Call` was just a no-op, but the performance without deserializing into an array had about a 10x improvement (for a batch size of 100, which I suspect is a bit too large).  For smaller batch sizes (batches of 10), the performance improvement was 40x.