### PR TITLE
feat(EnterLeave): Adds simplistic approach for adding enter/leave mouse events

### DIFF
--- a/ReactWindows/ReactNative.Shared/UIManager/Events/TouchEventType.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/Events/TouchEventType.cs
@@ -25,5 +25,15 @@
         /// Touch cancel event type.
         /// </summary>
         Cancel,
+
+        /// <summary>
+        /// Pointer entered event type.
+        /// </summary>
+        Entered,
+
+        /// <summary>
+        /// Pointer exited event type.
+        /// </summary>
+        Exited,
     }
 }

--- a/ReactWindows/ReactNative.Shared/UIManager/Events/TouchEventTypeExtensions.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/Events/TouchEventTypeExtensions.cs
@@ -16,6 +16,10 @@ namespace ReactNative.UIManager.Events
                     return "topTouchMove";
                 case TouchEventType.Cancel:
                     return "topTouchCancel";
+                case TouchEventType.Entered:
+                    return "topMouseOver";
+                case TouchEventType.Exited:
+                    return "topMouseOut";
                 default:
                     throw new NotSupportedException("Unsupported touch event type.");
             }

--- a/ReactWindows/ReactNative.Shared/UIManager/RootViewHelper.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/RootViewHelper.cs
@@ -59,10 +59,9 @@ namespace ReactNative.UIManager
                     yield break;
                 }
 
-                var uiElement = current as UIElement;
-                if (uiElement != null && uiElement.HasTag())
+                if (current.HasTag())
                 {
-                    yield return uiElement;
+                    yield return current;
                 }
 
                 current = GetParent(current, false);

--- a/ReactWindows/ReactNative.Shared/UIManager/RootViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/RootViewManager.cs
@@ -28,6 +28,19 @@
         }
 
         /// <summary>
+        /// Used to install custom event emitters on the given view.
+        /// </summary>
+        /// <param name="reactContext">The React context.</param>
+        /// <param name="view">The view.</param>
+        /// <remarks>
+        /// Intentionally skipping call to base method because we don't care
+        /// about pointer enter/leave events on the root view.
+        /// </remarks>
+        protected override void AddEventEmitters(ThemedReactContext reactContext, SizeMonitoringCanvas view)
+        {
+        }
+
+        /// <summary>
         /// Creates a new view instance of type <see cref="Windows.UI.Xaml.Controls.Panel"/>.
         /// </summary>
         /// <param name="reactContext">The React context.</param>

--- a/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.Constants.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.Constants.cs
@@ -146,6 +146,34 @@ namespace ReactNative.UIManager
                         }
                     }
                 },
+                {
+                    TouchEventType.Entered.GetJavaScriptEventName(),
+                    new Map
+                    {
+                        {
+                            "phasedRegistrationNames",
+                            new Map
+                            {
+                                { "bubbled", "onMouseOver" },
+                                { "captured", "onMouseOverCapture" },
+                            }
+                        }
+                    }
+                },
+                {
+                    TouchEventType.Exited.GetJavaScriptEventName(),
+                    new Map
+                    {
+                        {
+                            "phasedRegistrationNames",
+                            new Map
+                            {
+                                { "bubbled", "onMouseOut" },
+                                { "captured", "onMouseOutCapture" },
+                            }
+                        }
+                    }
+                },
             };
         }
 
@@ -189,17 +217,17 @@ namespace ReactNative.UIManager
                     }
                 },
                 {
-                    "topMouseOver",
+                    "topMouseEnter",
                     new Map
                     {
-                        { "registrationName", "onMouseOver" },
+                        { "registrationName", "onMouseEnter" },
                     }
                 },
                 {
-                    "topMouseOut",
+                    "topMouseLeave",
                     new Map
                     {
-                        { "registrationName", "onMouseOut" },
+                        { "registrationName", "onMouseLeave" },
                     }
                 },
             };

--- a/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.Constants.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/UIManagerModule.Constants.cs
@@ -188,6 +188,20 @@ namespace ReactNative.UIManager
                         { "registrationName", "onLayout" },
                     }
                 },
+                {
+                    "topMouseOver",
+                    new Map
+                    {
+                        { "registrationName", "onMouseOver" },
+                    }
+                },
+                {
+                    "topMouseOut",
+                    new Map
+                    {
+                        { "registrationName", "onMouseOut" },
+                    }
+                },
             };
         }
 

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewManager.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewManager.cs
@@ -120,14 +120,10 @@ namespace ReactNative.UIManager
 
         /// <summary>
         /// Called when view is detached from view hierarchy and allows for 
-        /// additional cleanup by the <see cref="IViewManager"/>
-        /// subclass.
+        /// additional cleanup by the <see cref="IViewManager"/> subclass.
         /// </summary>
         /// <param name="reactContext">The React context.</param>
         /// <param name="view">The view.</param>
-        /// <remarks>
-        /// Derived classes do not need to call this base method.
-        /// </remarks>
         public virtual void OnDropViewInstance(ThemedReactContext reactContext, TFrameworkElement view)
         {
         }

--- a/ReactWindows/ReactNative/Touch/TouchHandler.cs
+++ b/ReactWindows/ReactNative/Touch/TouchHandler.cs
@@ -389,11 +389,27 @@ namespace ReactNative.Touch
 
             public override void Dispatch(RCTEventEmitter eventEmitter)
             {
-                eventEmitter.receiveEvent(ViewTag, EventName, new JObject
+                var eventData = new JObject
                 {
                     { "target", ViewTag },
-                });
+                };
 
+                var enterLeaveEventName = default(string);
+                if (_touchEventType == TouchEventType.Entered)
+                {
+                    enterLeaveEventName = "topMouseEnter";
+                }
+                else if (_touchEventType == TouchEventType.Exited)
+                {
+                    enterLeaveEventName = "topMouseLeave";
+                }
+               
+                if (enterLeaveEventName != null)
+                {
+                    eventEmitter.receiveEvent(ViewTag, enterLeaveEventName, eventData);
+                }
+
+                eventEmitter.receiveEvent(ViewTag, EventName, eventData);
             }
         }
 

--- a/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
+++ b/ReactWindows/ReactNative/UIManager/BaseViewManager.cs
@@ -1,10 +1,12 @@
 ﻿using Newtonsoft.Json.Linq;
+using ReactNative.Touch;
 using ReactNative.UIManager.Annotations;
 using System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Media3D;
 
@@ -122,6 +124,53 @@ namespace ReactNative.UIManager
         public void SetTestId(TFrameworkElement view, string testId)
         {
             AutomationProperties.SetAutomationId(view, testId ?? "");
+        }
+
+        /// <summary>
+        /// Called when view is detached from view hierarchy and allows for 
+        /// additional cleanup by the <see cref="IViewManager"/> subclass.
+        /// </summary>
+        /// <param name="reactContext">The React context.</param>
+        /// <param name="view">The view.</param>
+        /// <remarks>
+        /// Be sure to call this base class method to register for pointer 
+        /// entered and pointer exited events.
+        /// </remarks>
+        public override void OnDropViewInstance(ThemedReactContext reactContext, TFrameworkElement view)
+        {
+            view.PointerEntered -= OnPointerEntered;
+            view.PointerExited -= OnPointerExited;
+        }
+
+        /// <summary>
+        /// Subclasses can override this method to install custom event 
+        /// emitters on the given view.
+        /// </summary>
+        /// <param name="reactContext">The React context.</param>
+        /// <param name="view">The view instance.</param>
+        /// <remarks>
+        /// Consider overriding this method if your view needs to emit events
+        /// besides basic touch events to JavaScript (e.g., scroll events).
+        /// 
+        /// Make sure you call the base implementation to ensure base pointer
+        /// event handlers are subscribed.
+        /// </remarks>
+        protected override void AddEventEmitters(ThemedReactContext reactContext, TFrameworkElement view)
+        {
+            view.PointerEntered += OnPointerEntered;
+            view.PointerExited += OnPointerExited;
+        }
+
+        private void OnPointerEntered(object sender, PointerRoutedEventArgs e)
+        {
+            var view = (TFrameworkElement)sender;
+            TouchHandler.OnPointerEntered(view, e);
+        }
+
+        private void OnPointerExited(object sender, PointerRoutedEventArgs e)
+        {
+            var view = (TFrameworkElement)sender;
+            TouchHandler.OnPointerExited(view, e);
         }
 
         private static void SetProjectionMatrix(TFrameworkElement view, JArray transforms)

--- a/ReactWindows/ReactNative/Views/Flip/ReactFlipViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Flip/ReactFlipViewManager.cs
@@ -92,6 +92,7 @@ namespace ReactNative.Views.Flip
 
         public override void OnDropViewInstance(ThemedReactContext reactContext, FlipView view)
         {
+            base.OnDropViewInstance(reactContext, view);
             view.SelectionChanged -= OnSelectionChanged;
         }
 
@@ -116,6 +117,7 @@ namespace ReactNative.Views.Flip
 
         protected override void AddEventEmitters(ThemedReactContext reactContext, FlipView view)
         {
+            base.AddEventEmitters(reactContext, view);
             view.SelectionChanged += OnSelectionChanged;
         }
 

--- a/ReactWindows/ReactNative/Views/Image/ReactImageManager.cs
+++ b/ReactWindows/ReactNative/Views/Image/ReactImageManager.cs
@@ -203,6 +203,8 @@ namespace ReactNative.Views.Image
         /// <param name="view">The view.</param>
         public override void OnDropViewInstance(ThemedReactContext reactContext, Border view)
         {
+            base.OnDropViewInstance(reactContext, view);
+
             var tag = view.GetTag();
             var disposable = default(SerialDisposable);
             if (_disposables.TryGetValue(tag, out disposable))

--- a/ReactWindows/ReactNative/Views/Picker/ReactPickerManager.cs
+++ b/ReactWindows/ReactNative/Views/Picker/ReactPickerManager.cs
@@ -123,6 +123,7 @@ namespace ReactNative.Views.Picker
         /// <param name="view">The view.</param>
         public override void OnDropViewInstance(ThemedReactContext reactContext, ComboBox view)
         {
+            base.OnDropViewInstance(reactContext, view);
             view.SelectionChanged -= OnSelectionChanged;
         }
   
@@ -144,6 +145,7 @@ namespace ReactNative.Views.Picker
         /// <param name="view">The view instance.</param>
         protected override void AddEventEmitters(ThemedReactContext reactContext, ComboBox view)
         {
+            base.AddEventEmitters(reactContext, view);
             view.SelectionChanged += OnSelectionChanged;
         }
 

--- a/ReactWindows/ReactNative/Views/Scroll/ReactScrollViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Scroll/ReactScrollViewManager.cs
@@ -269,6 +269,8 @@ namespace ReactNative.Views.Scroll
         /// <param name="view">The view.</param>
         public override void OnDropViewInstance(ThemedReactContext reactContext, ScrollViewer view)
         {
+            base.OnDropViewInstance(reactContext, view);
+
             _scrollViewerData.Remove(view);
 
             view.ViewChanging -= OnViewChanging;
@@ -330,6 +332,7 @@ namespace ReactNative.Views.Scroll
         /// <param name="view">The view instance.</param>
         protected override void AddEventEmitters(ThemedReactContext reactContext, ScrollViewer view)
         {
+            base.AddEventEmitters(reactContext, view);
             view.DirectManipulationCompleted += OnDirectManipulationCompleted;
             view.DirectManipulationStarted += OnDirectManipulationStarted;
             view.ViewChanging += OnViewChanging;

--- a/ReactWindows/ReactNative/Views/Slider/ReactSliderManager.cs
+++ b/ReactWindows/ReactNative/Views/Slider/ReactSliderManager.cs
@@ -128,6 +128,20 @@ namespace ReactNative.Views.Slider
         }
 
         /// <summary>
+        /// Called when view is detached from view hierarchy and allows for 
+        /// additional cleanup by the <see cref="IViewManager"/> subclass.
+        /// </summary>
+        /// <param name="reactContext">The React context.</param>
+        /// <param name="view">The view.</param>
+        public override void OnDropViewInstance(ThemedReactContext reactContext, Windows.UI.Xaml.Controls.Slider view)
+        {
+            base.OnDropViewInstance(reactContext, view);
+            view.ValueChanged -= OnValueChange;
+            view.PointerReleased -= OnPointerReleased;
+            view.PointerCaptureLost -= OnPointerReleased;
+        }
+
+        /// <summary>
         /// Implement this method to receive optional extra data enqueued from
         /// the corresponding instance of <see cref="ReactShadowNode"/> in
         /// <see cref="ReactShadowNode.OnCollectExtraUpdates"/>.
@@ -156,6 +170,7 @@ namespace ReactNative.Views.Slider
         /// <param name="view">The view instance.</param>
         protected override void AddEventEmitters(ThemedReactContext reactContext, Windows.UI.Xaml.Controls.Slider view)
         {
+            base.AddEventEmitters(reactContext, view);
             view.ValueChanged += OnValueChange;
             view.PointerReleased += OnPointerReleased;
             view.PointerCaptureLost += OnPointerReleased;

--- a/ReactWindows/ReactNative/Views/Split/ReactSplitViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Split/ReactSplitViewManager.cs
@@ -148,6 +148,7 @@ namespace ReactNative.Views.Split
 
         public override void OnDropViewInstance(ThemedReactContext reactContext, SplitView view)
         {
+            base.OnDropViewInstance(reactContext, view);
             view.PaneClosed -= OnPaneClosed;
         }
 
@@ -201,6 +202,7 @@ namespace ReactNative.Views.Split
 
         protected override void AddEventEmitters(ThemedReactContext reactContext, SplitView view)
         {
+            base.AddEventEmitters(reactContext, view);
             view.PaneClosed += OnPaneClosed;
         }
 

--- a/ReactWindows/ReactNative/Views/Switch/ReactSwitchManager.cs
+++ b/ReactWindows/ReactNative/Views/Switch/ReactSwitchManager.cs
@@ -88,6 +88,7 @@ namespace ReactNative.Views.Switch
         /// <param name="view">The view.</param>
         public override void OnDropViewInstance(ThemedReactContext reactContext, ToggleSwitch view)
         {
+            base.OnDropViewInstance(reactContext, view);
             view.Toggled -= OnToggled;
         }
 
@@ -112,6 +113,7 @@ namespace ReactNative.Views.Switch
         /// <param name="view">The view instance.</param>
         protected override void AddEventEmitters(ThemedReactContext reactContext, ToggleSwitch view)
         {
+            base.AddEventEmitters(reactContext, view);
             view.Toggled += OnToggled;
         }
 

--- a/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
@@ -360,6 +360,7 @@ namespace ReactNative.Views.TextInput
         /// <param name="view">The <see cref="PasswordBox"/> view instance.</param>
         protected override void AddEventEmitters(ThemedReactContext reactContext, PasswordBox view)
         {
+            base.AddEventEmitters(reactContext, view);
             view.PasswordChanged += OnPasswordChanged;
             view.GotFocus += OnGotFocus;
             view.LostFocus += OnLostFocus;
@@ -375,6 +376,7 @@ namespace ReactNative.Views.TextInput
         /// <param name="view">The <see cref="PasswordBox"/>.</param>
         public override void OnDropViewInstance(ThemedReactContext reactContext, PasswordBox view)
         {
+            base.OnDropViewInstance(reactContext, view);
             view.KeyDown -= OnKeyDown;
             view.LostFocus -= OnLostFocus;
             view.GotFocus -= OnGotFocus;

--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
@@ -464,6 +464,7 @@ namespace ReactNative.Views.TextInput
         /// <param name="view">The <see cref="ReactTextBox"/>.</param>
         public override void OnDropViewInstance(ThemedReactContext reactContext, ReactTextBox view)
         {
+            base.OnDropViewInstance(reactContext, view);
             view.KeyDown -= OnKeyDown;
             view.LostFocus -= OnLostFocus;
             view.GotFocus -= OnGotFocus;
@@ -498,6 +499,7 @@ namespace ReactNative.Views.TextInput
         /// <param name="view">The <see cref="ReactTextBox"/> view instance.</param>
         protected override void AddEventEmitters(ThemedReactContext reactContext, ReactTextBox view)
         {
+            base.AddEventEmitters(reactContext, view);
             view.TextChanging += OnTextChanging;
             view.TextChanged += OnTextChanged;
             view.GotFocus += OnGotFocus;

--- a/ReactWindows/ReactNative/Views/Web/ReactWebViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Web/ReactWebViewManager.cs
@@ -196,6 +196,7 @@ namespace ReactNative.Views.Web
         /// <param name="view">The view.</param>
         public override void OnDropViewInstance(ThemedReactContext reactContext, WebView view)
         {
+            base.OnDropViewInstance(reactContext, view);
             view.NavigationCompleted -= OnNavigationCompleted;
             view.NavigationStarting -= OnNavigationStarting;
         }
@@ -218,6 +219,7 @@ namespace ReactNative.Views.Web
         /// <param name="view">The view instance.</param>
         protected override void AddEventEmitters(ThemedReactContext reactContext, WebView view)
         {
+            base.AddEventEmitters(reactContext, view);
             view.NavigationCompleted += OnNavigationCompleted;
             view.NavigationStarting += OnNavigationStarting;
         }


### PR DESCRIPTION
A first approach at adding mouseenter/mouseleave events for react-native-windows. We may eventually want to considering adding a specific event plugin for this (to implement behavior like "capture" without "bubbling").

Fixes #775