### PR TITLE
fix(ReactBridge): Add missing case for null batched bridge response

### DIFF
--- a/ReactWindows/ReactNative.Shared/Bridge/ReactBridge.cs
+++ b/ReactWindows/ReactNative.Shared/Bridge/ReactBridge.cs
@@ -105,6 +105,11 @@ namespace ReactNative.Bridge
 
         private void ProcessResponse(JToken response)
         {
+            if (response == null || response.Type == JTokenType.Null || response.Type == JTokenType.Undefined)
+            {
+                return;
+            }
+
             var messages = response as JArray;
             if (messages == null)
             {


### PR DESCRIPTION
Recent change to batched bridge lost behavior to quietly ignore null payloads from the flushed queue.