### PR TITLE
fix(FrameBasedAnimationDriver): (should) reduce choppiness of animation

### DIFF
--- a/ReactWindows/ReactNative.Shared/Animated/FrameBasedAnimationDriver.cs
+++ b/ReactWindows/ReactNative.Shared/Animated/FrameBasedAnimationDriver.cs
@@ -6,6 +6,8 @@ namespace ReactNative.Animated
 {
     class FrameBasedAnimationDriver : AnimationDriver
     {
+        private const double FrameTimeMilliseconds = 1000.0 / 60.0;
+
         private readonly double[] _frames;
         private readonly double _toValue;
 
@@ -27,10 +29,10 @@ namespace ReactNative.Animated
                 _fromValue = AnimatedValue.Value;
             }
 
-            var timeFromStartTicks = (renderingTime.Ticks - _startFrameTimeTicks);
+            var timeFromStartTicks = (renderingTime.Ticks - _startFrameTimeTicks) / 10000.0;
             // frames are calcualted at 60FPS, to get index by a given time offset from the start of the
             // animation, we take the time diff in milliseconds and divide it by 60 frames per 1000ms.
-            var frameIndex = (int)(timeFromStartTicks / 10000 * 60 / 1000);
+            var frameIndex = (int)(timeFromStartTicks / FrameTimeMilliseconds);
             if (frameIndex < 0)
             {
                 throw new InvalidOperationException("Calculated frame index should never be lower than 0.");

--- a/ReactWindows/ReactNative.Shared/Animated/InterpolationAnimatedNode.cs
+++ b/ReactWindows/ReactNative.Shared/Animated/InterpolationAnimatedNode.cs
@@ -134,7 +134,7 @@ namespace ReactNative.Animated
         private static int FindRangeIndex(double value, double[] ranges)
         {
             var index = 1;
-            for (; index < ranges.Length; ++index)
+            for (; index < ranges.Length - 1; index++)
             {
                 if (ranges[index] >= value)
                 {

--- a/ReactWindows/ReactNative.Shared/Animated/InterpolationAnimatedNode.cs
+++ b/ReactWindows/ReactNative.Shared/Animated/InterpolationAnimatedNode.cs
@@ -1,12 +1,19 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
+using static System.FormattableString;
 
 namespace ReactNative.Animated
 {
     class InterpolationAnimatedNode : ValueAnimatedNode
     {
+        public const string ExtrapolateTypeIdentity = "identity";
+        public const string ExtrapolateTypeClamp = "clamp";
+        public const string ExtrapolateTypeExtend = "extend";
+        
         private readonly double[] _inputRange;
         private readonly double[] _outputRange;
+        private readonly string _extrapolateLeft;
+        private readonly string _extrapolateRight;
 
         private ValueAnimatedNode _parent;
 
@@ -15,6 +22,8 @@ namespace ReactNative.Animated
         {
             _inputRange = config.GetValue("inputRange", StringComparison.Ordinal).ToObject<double[]>();
             _outputRange = config.GetValue("outputRange", StringComparison.Ordinal).ToObject<double[]>();
+            _extrapolateLeft = config.Value<string>("extrapolateLeft");
+            _extrapolateRight = config.Value<string>("extrapolateRight");
         }
 
         protected override void OnAttachedToNode(AnimatedNode parent)
@@ -51,7 +60,7 @@ namespace ReactNative.Animated
                     "Trying to update interpolation node that has not been attached to the parent.");
             }
 
-            Value = Interpolate(_parent.Value, _inputRange, _outputRange);
+            Value = Interpolate(_parent.Value, _inputRange, _outputRange, _extrapolateLeft, _extrapolateRight);
         }
 
         private static double Interpolate(
@@ -59,13 +68,57 @@ namespace ReactNative.Animated
             double inputMin,
             double inputMax,
             double outputMin,
-            double outputMax)
+            double outputMax,
+            string extrapolateLeft,
+            string extrapolateRight)
         {
+            var result = value;
+
+            // Extrapolate
+            if (result < inputMin)
+            {
+                switch (extrapolateLeft)
+                {
+                    case ExtrapolateTypeIdentity:
+                        return result;
+                    case ExtrapolateTypeClamp:
+                        result = inputMin;
+                        break;
+                    case ExtrapolateTypeExtend:
+                        break;
+                    default:
+                        throw new InvalidOperationException(
+                            Invariant($"Invalid extrapolation type '{extrapolateLeft}' for left extrapolation."));
+                }
+            }
+
+            if (result > inputMax)
+            {
+                switch (extrapolateRight)
+                {
+                    case ExtrapolateTypeIdentity:
+                        return result;
+                    case ExtrapolateTypeClamp:
+                        result = inputMax;
+                        break;
+                    case ExtrapolateTypeExtend:
+                        break;
+                    default:
+                        throw new InvalidOperationException(
+                            Invariant($"Invalid extrapolation type '{extrapolateRight} for right extrapolation"));
+                }
+            }
+
             return outputMin + (outputMax - outputMin) *
-                (value - inputMin) / (inputMax - inputMin);
+                (result - inputMin) / (inputMax - inputMin);
         }
 
-        private static double Interpolate(double value, double[] inputRange, double[] outputRange)
+        private static double Interpolate(
+            double value, 
+            double[] inputRange, 
+            double[] outputRange,
+            string extrapolateLeft,
+            string extrapolateRight)
         {
             var rangeIndex = FindRangeIndex(value, inputRange);
             return Interpolate(
@@ -73,7 +126,9 @@ namespace ReactNative.Animated
                 inputRange[rangeIndex],
                 inputRange[rangeIndex + 1],
                 outputRange[rangeIndex],
-                outputRange[rangeIndex + 1]);
+                outputRange[rangeIndex + 1],
+                extrapolateLeft,
+                extrapolateRight);
         }
 
         private static int FindRangeIndex(double value, double[] ranges)

--- a/ReactWindows/ReactNative/Animated/DiffClampAnimatedNode.cs
+++ b/ReactWindows/ReactNative/Animated/DiffClampAnimatedNode.cs
@@ -1,0 +1,46 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+
+namespace ReactNative.Animated
+{
+    class DiffClampAnimatedNode : ValueAnimatedNode
+    {
+        private readonly NativeAnimatedNodesManager _nativeAnimatedNodesManager;
+        private readonly int _inputNodeTag;
+        private readonly double _min;
+        private readonly double _max;
+
+        private double _lastValue;
+
+        public DiffClampAnimatedNode(int tag, JObject config, NativeAnimatedNodesManager nativeAnimatedNodesManager) 
+            : base(tag, config)
+        {
+            _nativeAnimatedNodesManager = nativeAnimatedNodesManager;
+            _inputNodeTag = config.Value<int>("input");
+            _min = config.Value<double>("min");
+            _max = config.Value<double>("max");
+
+            Value = _lastValue = GetInputNodeValue();
+        }
+
+        public override void Update()
+        {
+            var value = GetInputNodeValue();
+
+            var diff = value - _lastValue;
+            _lastValue = value;
+            Value = Math.Min(Math.Max(Value + diff, _min), _max);
+        }
+
+        private double GetInputNodeValue()
+        {
+            var valueAnimatedNode = _nativeAnimatedNodesManager.GetNodeById(_inputNodeTag) as ValueAnimatedNode;
+            if (valueAnimatedNode == null) {
+                throw new InvalidOperationException(
+                    "Illegal node ID set as an input for Animated.DiffClamp node.");
+            }
+
+            return valueAnimatedNode.Value;
+        }
+    }
+}

--- a/ReactWindows/ReactNative/Animated/NativeAnimatedNodesManager.cs
+++ b/ReactWindows/ReactNative/Animated/NativeAnimatedNodesManager.cs
@@ -77,6 +77,9 @@ namespace ReactNative.Animated
                 case "multiplication":
                     node = new MultiplicationAnimatedNode(tag, config, this);
                     break;
+                case "diffclamp":
+                    node = new DiffClampAnimatedNode(tag, config, this);
+                    break;
                 case "transform":
                     node = new TransformAnimatedNode(tag, config, this);
                     break;

--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -95,6 +95,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Animated\AdditionAnimatedNode.cs" />
+    <Compile Include="Animated\DiffClampAnimatedNode.cs" />
     <Compile Include="Animated\MultiplicationAnimatedNode.cs" />
     <Compile Include="Animated\NativeAnimatedModule.cs" />
     <Compile Include="Animated\NativeAnimatedNodesManager.cs" />


### PR DESCRIPTION
Casting to long too early here and dropping some precision, resulting in skipped (not dropped) frames.