### PR TITLE
fix(TextInput): Perform more accurate measurement for PasswordBox

### DIFF
--- a/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxShadowNode.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxShadowNode.cs
@@ -5,7 +5,6 @@ using ReactNative.UIManager;
 using ReactNative.UIManager.Annotations;
 using ReactNative.Views.Text;
 using System;
-using System.Linq;
 using Windows.Foundation;
 using Windows.UI.Text;
 using Windows.UI.Xaml;
@@ -226,7 +225,6 @@ namespace ReactNative.Views.TextInput
             {
                 var textNode = (ReactPasswordBoxShadowNode)node;
 
-                var passwordBox = new PasswordBox();
                 var textBlock = new TextBlock
                 {
                     TextWrapping = TextWrapping.Wrap,
@@ -234,7 +232,7 @@ namespace ReactNative.Views.TextInput
 
                 var passwordChar = GetDefaultPasswordChar();
                 var normalizedText = !string.IsNullOrEmpty(textNode._text)
-                    ? string.Join("", Enumerable.Repeat(passwordChar, textNode._text.Length))
+                    ? new string(passwordChar[0], textNode._text.Length)
                     : passwordChar;
                 var inline = new Run { Text = normalizedText };
                 FormatTextElement(textNode, inline);


### PR DESCRIPTION
`PasswordBox.Measure(size)` does not result in a value being set for `PasswordBox.DesiredSize` property. The same goes for `TextBox`, which we worked around by measuring a `TextBlock` and including the `TextBox` margin values in the resulting measurement. Making the same change for `PasswordBox`.

Fixes #855