### PR TITLE
feat(NativeAnimated): Adds support for animated events

### DIFF
--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -143,6 +143,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\Dimensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\Events\Event.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\Events\EventDispatcher.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UIManager\Events\IEventDispatcherListener.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\Events\RCTEventEmitter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\Events\TouchEventType.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UIManager\Events\TouchEventTypeExtensions.cs" />

--- a/ReactWindows/ReactNative.Shared/UIManager/Events/IEventDispatcherListener.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/Events/IEventDispatcherListener.cs
@@ -1,0 +1,20 @@
+﻿namespace ReactNative.UIManager.Events
+{
+    /// <summary>
+    /// Interface used to intercept events dispatched by <see cref="EventDispatcher"/>.
+    /// </summary>
+    public interface IEventDispatcherListener
+    {
+        /// <summary>
+        /// Called on every time an event is dispatched using <see cref="EventDispatcher.DispatchEvent(Event)"/>. 
+        /// Will be called from the same thread that the event is being 
+        /// dispatched from.
+        /// </summary>
+        /// <param name="event">Event that was dispatched.</param>
+        /// <returns>
+        /// If the event was handled. If true the event won't be sent to 
+        /// JavaScript.
+        /// </returns>
+        bool OnEventDispatch(Event @event);
+    }
+}

--- a/ReactWindows/ReactNative.Shared/UIManager/Events/RCTEventEmitter.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/Events/RCTEventEmitter.cs
@@ -6,7 +6,7 @@ namespace ReactNative.UIManager.Events
     /// <summary>
     /// JavaScript event emitter.
     /// </summary>
-    public sealed class RCTEventEmitter : JavaScriptModuleBase
+    public class RCTEventEmitter : JavaScriptModuleBase
     {
         /// <summary>
         /// Receive an event.
@@ -14,7 +14,7 @@ namespace ReactNative.UIManager.Events
         /// <param name="targetTag">The target tag.</param>
         /// <param name="eventName">The event name.</param>
         /// <param name="event">The event data.</param>
-        public void receiveEvent(int targetTag, string eventName, JObject @event)
+        public virtual void receiveEvent(int targetTag, string eventName, JObject @event)
         {
             Invoke(targetTag, eventName, @event);
         }
@@ -25,7 +25,7 @@ namespace ReactNative.UIManager.Events
         /// <param name="eventName">The event name.</param>
         /// <param name="touches">The touches.</param>
         /// <param name="changedIndexes">The changed indices.</param>
-        public void receiveTouches(string eventName, JArray touches, JArray changedIndexes)
+        public virtual void receiveTouches(string eventName, JArray touches, JArray changedIndexes)
         {
             Invoke(eventName, touches, changedIndexes);
         }

--- a/ReactWindows/ReactNative/Animated/EventAnimationDriver.cs
+++ b/ReactWindows/ReactNative/Animated/EventAnimationDriver.cs
@@ -1,0 +1,47 @@
+﻿using Newtonsoft.Json.Linq;
+using ReactNative.UIManager.Events;
+using System;
+using System.Collections.Generic;
+using static System.FormattableString;
+
+namespace ReactNative.Animated
+{
+    class EventAnimationDriver : RCTEventEmitter
+    {
+        private readonly IList<string> _eventPath;
+
+        public EventAnimationDriver(IList<string> eventPath, ValueAnimatedNode valueNode)
+        {
+            _eventPath = eventPath;
+            ValueNode = valueNode;
+        }
+
+        public ValueAnimatedNode ValueNode
+        {
+            get;
+        }
+
+        public override void receiveEvent(int targetTag, string eventName, JObject @event)
+        {
+            if (@event == null)
+            {
+                throw new ArgumentNullException(nameof(@event), "Native animated events must have event data.");
+            }
+
+            // Get the new value for the node by looking into the event map using the provided event path.
+            var current = @event;
+            for (var i = 0; i < _eventPath.Count - 1; i++)
+            {
+                current = (JObject)current[_eventPath[i]];
+            }
+
+            ValueNode.Value = current.Value<double>(_eventPath[_eventPath.Count - 1]);
+        }
+
+        public override void receiveTouches(string eventName, JArray touches, JArray changedIndexes)
+        {
+            throw new NotSupportedException(
+                Invariant($"Method '{nameof(receiveTouches)}' is not support by native animated events."));
+        }
+    }
+}

--- a/ReactWindows/ReactNative/Animated/NativeAnimatedModule.cs
+++ b/ReactWindows/ReactNative/Animated/NativeAnimatedModule.cs
@@ -97,8 +97,8 @@ namespace ReactNative.Animated
         public override void Initialize()
         {
             var ctx = Context;
-            var uiImpl = ctx.GetNativeModule<UIManagerModule>().UIImplementation;
-            var nodesManager = new NativeAnimatedNodesManager(uiImpl);
+            var uiManager = ctx.GetNativeModule<UIManagerModule>();
+            var nodesManager = new NativeAnimatedNodesManager(uiManager);
             _animatedFrameCallback = (sender, args) =>
             {
                 try
@@ -308,7 +308,7 @@ namespace ReactNative.Animated
         /// Connects animated node to view.
         /// </summary>
         /// <param name="animatedNodeTag">Animated node tag.</param>
-        /// <param name="viewTag">React view tag.s</param>
+        /// <param name="viewTag">React view tag.</param>
         [ReactMethod]
         public void connectAnimatedNodeToView(int animatedNodeTag, int viewTag)
         {
@@ -326,6 +326,31 @@ namespace ReactNative.Animated
         {
             _operations.Add(manager =>
                 manager.DisconnectAnimatedNodeFromView(animatedNodeTag, viewTag));
+        }
+
+        /// <summary>
+        /// Adds an animated event to view.
+        /// </summary>
+        /// <param name="viewTag">The view tag.</param>
+        /// <param name="eventName">The event name.</param>
+        /// <param name="eventMapping">The event mapping.</param>
+        [ReactMethod]
+        public void addAnimatedEventToView(int viewTag, string eventName, JObject eventMapping)
+        {
+            _operations.Add(manager =>
+                manager.AddAnimatedEventToView(viewTag, eventName, eventMapping));
+        }
+
+        /// <summary>
+        /// Removes an animated event from view.
+        /// </summary>
+        /// <param name="viewTag">The view tag.</param>
+        /// <param name="eventName">The event name.</param>
+        [ReactMethod]
+        public void removeAnimatedEventFromView(int viewTag, string eventName)
+        {
+            _operations.Add(manager =>
+                manager.RemoveAnimatedEventFromView(viewTag, eventName));
         }
     }
 }

--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Animated\AdditionAnimatedNode.cs" />
     <Compile Include="Animated\DiffClampAnimatedNode.cs" />
     <Compile Include="Animated\DivisionAnimatedNode.cs" />
+    <Compile Include="Animated\EventAnimationDriver.cs" />
     <Compile Include="Animated\MultiplicationAnimatedNode.cs" />
     <Compile Include="Animated\NativeAnimatedModule.cs" />
     <Compile Include="Animated\NativeAnimatedNodesManager.cs" />


### PR DESCRIPTION
This adds support for `Animated.event` driven natively.

At the moment, it works by providing a mapping between a view tag, an event name, an event path and an animated value when a view has a prop with a `AnimatedEvent` object. Then we can hook into `EventDispatcher`, check for events that target our view + event name and update the animated value using the event path.

For now it works with the onScroll event but it should be generic enough to work with anything.