### PR TITLE
Do not create app bundles when using run-windows

### DIFF
--- a/local-cli/runWindows/utils/msbuildtools.js
+++ b/local-cli/runWindows/utils/msbuildtools.js
@@ -31,7 +31,8 @@ class MSBuildTools {
       '/clp:NoSummary;NoItemAndPropertyList;Verbosity=minimal',
       '/nologo',
       `/p:Configuration=${buildType}`,
-      `/p:Platform=${buildArch}`
+      `/p:Platform=${buildArch}`,
+      '/p:AppxBundle=Never'
     ];
 
     if (config) {


### PR DESCRIPTION
This fixes issue [After creating app packages, react-native run-windows fails with a build error](https://github.com/ReactWindows/react-native-windows/issues/876)

Using run-windows builds the code in debug mode, and is not meant for bundling. If the app has been previously bundled, the build process will attempt to create it.

This change tells msbuild not to create any bundles.