### PR TITLE
fix(LayoutAnimation): Ensure view still exists before dropping

### DIFF
--- a/ReactWindows/ReactNative.Shared/UIManager/NativeViewHierarchyManager.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/NativeViewHierarchyManager.cs
@@ -288,8 +288,10 @@ namespace ReactNative.UIManager
                     {
                         _layoutAnimator.DeleteView(elementToDestroy, () =>
                         {
-                            viewParentManager.RemoveView(viewToManage, viewToDestroy);
-                            DropView(viewToDestroy);
+                            if (viewParentManager.TryRemoveView(viewToManage, viewToDestroy))
+                            {
+                                DropView(viewToDestroy);
+                            }
                         });
                     }
                     else

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewParentManagerExtensions.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewParentManagerExtensions.cs
@@ -12,11 +12,14 @@ namespace ReactNative.UIManager
     public static class ViewParentManagerExtensions
     {
         /// <summary>
-        /// Remove a view from a <see cref="IViewParentManager"/>. 
+        /// Tries to remove a view from a <see cref="IViewParentManager"/>. 
         /// </summary>
         /// <param name="viewManager">The view manager.</param>
         /// <param name="parent">The parent view.</param>
         /// <param name="view">The view to remove.</param>
+        /// <returns>
+        /// <code>true</code> if a view is removed, <code>false</code> otherwise.
+        /// </returns>
         public static bool TryRemoveView(this IViewParentManager viewManager, DependencyObject parent, DependencyObject view)
         {
             for (var i = 0; i < viewManager.GetChildCount(parent); ++i)

--- a/ReactWindows/ReactNative.Shared/UIManager/ViewParentManagerExtensions.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewParentManagerExtensions.cs
@@ -17,16 +17,18 @@ namespace ReactNative.UIManager
         /// <param name="viewManager">The view manager.</param>
         /// <param name="parent">The parent view.</param>
         /// <param name="view">The view to remove.</param>
-        public static void RemoveView(this IViewParentManager viewManager, DependencyObject parent, DependencyObject view)
+        public static bool TryRemoveView(this IViewParentManager viewManager, DependencyObject parent, DependencyObject view)
         {
             for (var i = 0; i < viewManager.GetChildCount(parent); ++i)
             {
                 if (viewManager.GetChildAt(parent, i) == view)
                 {
                     viewManager.RemoveChildAt(parent, i);
-                    break;
+                    return true;
                 }
             }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
When using layout animation, dropping a view can be deferred if the delete action is animated with layout animation.

If, while the layout animation is processing, a parent container of the view being animated is also removed, then the animated view will simply be dropped (even though the layout animation is still processing).

To prevent an exception from occurring due to this behavior, the animation end callback for drop layout animations checks first that it is safe to finalize dropping the view.

Fixes #861