### PR TITLE
Fixed issue where text was clipping instead of wrapping

### DIFF
--- a/ReactWindows/Playground.Net46/index.windows.js
+++ b/ReactWindows/Playground.Net46/index.windows.js
@@ -37,19 +37,17 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#F5FCFF',
+    backgroundColor: '#F5FCFF'
   },
   welcome: {
     fontSize: 20,
     textAlign: 'center',
-    margin: 10,
-    width: 500
+    margin: 10
   },
   instructions: {
     textAlign: 'center',
     color: '#333333',
-    marginBottom: 5,
-    width: 500
+    marginBottom: 5
   },
 });
 

--- a/ReactWindows/ReactNative.Net46/Views/Text/ReactTextShadowNode.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Text/ReactTextShadowNode.cs
@@ -1,4 +1,5 @@
-﻿using Facebook.CSSLayout;
+﻿using System;
+using Facebook.CSSLayout;
 using ReactNative.Bridge;
 using ReactNative.Reflection;
 using ReactNative.UIManager;
@@ -195,6 +196,7 @@ namespace ReactNative.Views.Text
                 var textBlock = new TextBlock
                 {
                     TextAlignment = TextAlignment.Left,
+                    TextWrapping = TextWrapping.Wrap,
                     TextTrimming = TextTrimming.CharacterEllipsis,
                 };
 
@@ -210,8 +212,8 @@ namespace ReactNative.Views.Text
                 var normalizedHeight = CSSConstants.IsUndefined(height) ? double.PositiveInfinity : height;
                 textBlock.Measure(new Size(normalizedWidth, normalizedHeight));
                 return new MeasureOutput(
-                    (float)textBlock.DesiredSize.Width,
-                    (float)textBlock.DesiredSize.Height);
+                    (float)Math.Ceiling(textBlock.DesiredSize.Width),
+                    (float)Math.Ceiling(textBlock.DesiredSize.Height));
             });
 
             return task.Result;

--- a/ReactWindows/ReactNative.Net46/Views/Text/ReactTextShadowNode.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Text/ReactTextShadowNode.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using Facebook.CSSLayout;
+﻿using Facebook.CSSLayout;
 using ReactNative.Bridge;
 using ReactNative.Reflection;
 using ReactNative.UIManager;
 using ReactNative.UIManager.Annotations;
+using System;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Documents;
 using System.Windows.Media;
 
 namespace ReactNative.Views.Text

--- a/ReactWindows/ReactNative.Net46/Views/Text/ReactTextViewManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Text/ReactTextViewManager.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using ReactNative.UIManager;
+﻿using ReactNative.UIManager;
 using ReactNative.UIManager.Annotations;
+using System;
 using System.Collections;
-using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;

--- a/ReactWindows/ReactNative.Net46/Views/Text/ReactTextViewManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Text/ReactTextViewManager.cs
@@ -158,6 +158,7 @@ namespace ReactNative.Views.Text
             var textBlock = new TextBlock
             {
                 TextAlignment = TextAlignment.Left,
+                TextWrapping = TextWrapping.Wrap,
                 TextTrimming = TextTrimming.CharacterEllipsis,
             };
 


### PR DESCRIPTION
Text still properly clips if you set a width/height smaller than the content, but no longer clips when width/height aren't specifically defined.