### PR TITLE
test(TaskCancellationManager): Fix non-deterministic unit tests

### DIFF
--- a/ReactWindows/ReactNative.Shared.Tests/Modules/Network/TaskCancellationManagerTests.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/Modules/Network/TaskCancellationManagerTests.cs
@@ -18,10 +18,10 @@ namespace ReactNative.Tests.Modules.Network
         }
 
         [Test]
-        public void TaskCancellationManager_CancelledAfterCompleted()
+        public async void TaskCancellationManager_CancelledAfterCompleted()
         {
             var mgr = new TaskCancellationManager<int>();
-            mgr.Add(42, _ => Task.CompletedTask);
+            await mgr.Add(42, _ => Task.CompletedTask);
             mgr.Cancel(42);
 
             // Not throwing implies success
@@ -55,10 +55,9 @@ namespace ReactNative.Tests.Modules.Network
             var enter = new AutoResetEvent(false);
             var exit = new AutoResetEvent(false);
             var mgr = new TaskCancellationManager<int>();
-            var t = default(Task);
-            mgr.Add(42, token =>
+            var t = mgr.Add(42, token =>
             {
-                return t = Task.Run(() =>
+                return Task.Run(() =>
                 {
                     enter.WaitOne();
                     return;
@@ -77,10 +76,9 @@ namespace ReactNative.Tests.Modules.Network
         {
             var enter = new AutoResetEvent(false);
             var mgr = new TaskCancellationManager<int>();
-            var t = default(Task);
-            mgr.Add(42, token =>
+            var t = mgr.Add(42, token =>
             {
-                return t = Task.Run(() =>
+                return Task.Run(() =>
                 {
                     enter.WaitOne();
                     throw new InvalidOperationException();

--- a/ReactWindows/ReactNative.Shared.Tests/Modules/Network/TaskCancellationManagerTests.cs
+++ b/ReactWindows/ReactNative.Shared.Tests/Modules/Network/TaskCancellationManagerTests.cs
@@ -18,7 +18,7 @@ namespace ReactNative.Tests.Modules.Network
         }
 
         [Test]
-        public async void TaskCancellationManager_CancelledAfterCompleted()
+        public async Task TaskCancellationManager_CancelledAfterCompleted()
         {
             var mgr = new TaskCancellationManager<int>();
             await mgr.Add(42, _ => Task.CompletedTask);
@@ -28,12 +28,12 @@ namespace ReactNative.Tests.Modules.Network
         }
 
         [Test]
-        public void TaskCancellationManager_CancelTask()
+        public async Task TaskCancellationManager_CancelTask()
         {
             var enter = new AutoResetEvent(false);
             var exit = new AutoResetEvent(false);
             var mgr = new TaskCancellationManager<int>();
-            mgr.Add(42, async token =>
+            var t = mgr.Add(42, async token =>
             {
                 var tcs = new TaskCompletionSource<bool>();
                 using (token.Register(() => tcs.SetResult(true)))
@@ -47,6 +47,7 @@ namespace ReactNative.Tests.Modules.Network
             Assert.IsTrue(enter.WaitOne());
             mgr.Cancel(42);
             Assert.IsTrue(exit.WaitOne());
+            await t;
         }
 
         [Test]


### PR DESCRIPTION
TaskCancellationManager unit tests had assumptions about the ExecuteSynchronously continuation option used internally to the TaskCancellationManager that were invalid. To alleviate this, I've added a return Task to await the actual completion of the wrapped task.

Fixes #947