### PR TITLE
make color helpers public

### DIFF
--- a/ReactWindows/ReactNative.Shared/UIManager/ColorHelpers.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ColorHelpers.cs
@@ -6,7 +6,7 @@ using System.Windows.Media;
 
 namespace ReactNative.UIManager
 {
-    static class ColorHelpers
+    public static class ColorHelpers
     {
         public const uint Transparent = 0x00FFFFFF;
 


### PR DESCRIPTION
Color Helpers are useful to third-party libraries, so let's make it public. Simple enough.