### PR TITLE
Fix incorrect function name for getInitialURL in LauncherModule (#959)

### DIFF
--- a/ReactWindows/ReactNative/Modules/Launch/LauncherModule.cs
+++ b/ReactWindows/ReactNative/Modules/Launch/LauncherModule.cs
@@ -117,7 +117,7 @@ namespace ReactNative.Modules.Launch
         /// The promise used to return the initial URL.
         /// </param>
         [ReactMethod]
-        public void getInitialUrl(IPromise promise)
+        public void getInitialURL(IPromise promise)
         {
             promise.Resolve(s_activatedUrl);
         }


### PR DESCRIPTION
See #959 