### PR TITLE
Added proxy support for requests made by fetch

### DIFF
--- a/local-cli/rnpm/windows/src/common.js
+++ b/local-cli/rnpm/windows/src/common.js
@@ -13,6 +13,13 @@ const fs = require('fs');
 const path = require('path');
 const semver = require('semver');
 const fetch = require('node-fetch');
+const HttpsProxyAgent = require('https-proxy-agent');
+
+const proxyUrl = process.env.https_proxy || process.env.HTTPS_PROXY;
+const options  = {};
+if(proxyUrl) {
+  options.agent = new HttpsProxyAgent(proxyUrl);
+}
 
 const REACT_NATIVE_PACKAGE_JSON_PATH = function() {
   return path.resolve(
@@ -24,14 +31,14 @@ const REACT_NATIVE_PACKAGE_JSON_PATH = function() {
 };
 
 function getLatestVersion() {
-  return fetch('https://registry.npmjs.org/react-native-windows?version=latest')
+  return fetch('https://registry.npmjs.org/react-native-windows?version=latest', options)
     .then(result => result && result.ok && result.json())
     .then(result => result.version)
 }
 
 function getMatchingVersion(version) {
   console.log(`Checking for react-native-windows version matching ${version}...`)
-  return fetch(`https://registry.npmjs.org/react-native-windows?version=${version}`)
+  return fetch(`https://registry.npmjs.org/react-native-windows?version=${version}`, options)
     .then(result => {
       if (result && result.ok) {
         return result.json().then(pkg => pkg.version);

--- a/local-cli/rnpm/wpf/src/wpf.js
+++ b/local-cli/rnpm/wpf/src/wpf.js
@@ -15,6 +15,13 @@ const fs = require('fs');
 const path = require('path');
 const semver = require('semver');
 const fetch = require('node-fetch');
+const HttpsProxyAgent = require('https-proxy-agent');
+
+const proxyUrl = process.env.https_proxy || process.env.HTTPS_PROXY;
+const options  = {};
+if(proxyUrl) {
+  options.agent = new HttpsProxyAgent(proxyUrl);
+}
 
 const REACT_NATIVE_WINDOWS_GENERATE_PATH = function() {
   return path.resolve(
@@ -36,14 +43,14 @@ const REACT_NATIVE_PACKAGE_JSON_PATH = function() {
 };
 
 function getLatestVersion() {
-  return fetch('https://registry.npmjs.org/react-native-windows?version=latest')
+  return fetch('https://registry.npmjs.org/react-native-windows?version=latest', options)
     .then(result => result && result.ok && result.json())
     .then(result => result.version)
 }
 
 function getMatchingVersion(version) {
   console.log(`Checking for react-native-windows version matching ${version}...`)
-  return fetch(`https://registry.npmjs.org/react-native-windows?version=${version}`)
+  return fetch(`https://registry.npmjs.org/react-native-windows?version=${version}`, options)
     .then(result => {
       if (result && result.ok) {
         return result.json().then(pkg => pkg.version);

--- a/package.json
+++ b/package.json
@@ -29,10 +29,11 @@
     "react": "~15.4.0-rc.4"
   },
   "devDependencies": {
+    "https-proxy-agent": "^1.0.0",
     "jasmine": "^2.5.2",
     "jasmine-reporters": "^2.2.0",
-    "react-native": "~0.39.0-rc.0",
     "react": "~15.4.0-rc.4",
+    "react-native": "~0.39.0-rc.0",
     "selenium-webdriver": "2.48.x"
   },
   "dependencies": {


### PR DESCRIPTION
If `https_proxy` or `HTTPS_PROXY` environment variable is set, the fetch function in RNPM Plugin for Universal Windows / Universal Windows WPF will make use of it for making requests.

Solves #879.