### PR TITLE
Fix TextInput layout not taking height into account

### DIFF
--- a/ReactWindows/ReactNative.Net46/Views/TextInput/ReactPasswordBoxManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/TextInput/ReactPasswordBoxManager.cs
@@ -384,6 +384,7 @@ namespace ReactNative.Views.TextInput
             Canvas.SetLeft(view, dimensions.X);
             Canvas.SetTop(view, dimensions.Y);
             view.Width = dimensions.Width;
+            view.Height = dimensions.Height;
         }
 
         private void OnPasswordChanged(object sender, RoutedEventArgs e)

--- a/ReactWindows/ReactNative.Net46/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative.Net46/Views/TextInput/ReactTextInputManager.cs
@@ -471,6 +471,7 @@ namespace ReactNative.Views.TextInput
             Canvas.SetLeft(view, dimensions.X);
             Canvas.SetTop(view, dimensions.Y);
             view.Width = dimensions.Width;
+            view.Height = dimensions.Height;
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactPasswordBoxManager.cs
@@ -387,6 +387,7 @@ namespace ReactNative.Views.TextInput
             Canvas.SetLeft(view, dimensions.X);
             Canvas.SetTop(view, dimensions.Y);
             view.Width = dimensions.Width;
+            view.Height = dimensions.Height;
         }
 
         private void OnPasswordChanged(object sender, RoutedEventArgs e)

--- a/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
+++ b/ReactWindows/ReactNative/Views/TextInput/ReactTextInputManager.cs
@@ -477,6 +477,7 @@ namespace ReactNative.Views.TextInput
             Canvas.SetLeft(view, dimensions.X);
             Canvas.SetTop(view, dimensions.Y);
             view.Width = dimensions.Width;
+            view.Height = dimensions.Height;
         }
 
         /// <summary>


### PR DESCRIPTION
TextInput height was not set according to the RN layout.
Is the height not set here on purpose, or was it just forgotten ? Setting the height fixed the issue for me. My layout is now consistent on iOS and UWP.