### PR TITLE
fix(CLI): Windows project generator broke due to changes to HTTP registry API

### DIFF
--- a/local-cli/rnpm/windows/package.json
+++ b/local-cli/rnpm/windows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rnpm-plugin-windows",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "rnpm plugin that generates a Windows template project",
   "main": "index.js",
   "scripts": {
@@ -24,8 +24,8 @@
     "react-native": ">=0.31.0"
   },
   "dependencies": {
-    "semver": "^5.0.3",
     "chalk": "^1.1.3",
-    "node-fetch": "^1.3.3"
+    "npm-registry": "^0.1.13",
+    "semver": "^5.0.3"
   }
 }

--- a/local-cli/rnpm/windows/src/common.js
+++ b/local-cli/rnpm/windows/src/common.js
@@ -29,11 +29,13 @@ const npm = new Registry({registry: NPM_REGISTRY_URL})
 
 function getLatestVersion() {
   return new Promise(function (resolve, reject) {
-    npm.packages.release('react-native-windows', 'latest', (err, release) => {
+    npm.packages.release('react-native-windows', 'latest', (err, releases) => {
       if (err) {
         reject(err)
+      } else if (releases.length == 0) {
+        reject(new Error(`Could not find react-native-windows@latest.`))
       } else {
-        resolve(release.version)
+        resolve(releases[0].version)
       }
     })
   })

--- a/local-cli/rnpm/windows/src/common.js
+++ b/local-cli/rnpm/windows/src/common.js
@@ -7,19 +7,14 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-'use strict';
+'use strict'
 
-const fs = require('fs');
-const path = require('path');
-const semver = require('semver');
-const fetch = require('node-fetch');
-const HttpsProxyAgent = require('https-proxy-agent');
+const fs = require('fs')
+const path = require('path')
+const semver = require('semver')
+const Registry = require('npm-registry')
 
-const proxyUrl = process.env.https_proxy || process.env.HTTPS_PROXY;
-const options  = {};
-if(proxyUrl) {
-  options.agent = new HttpsProxyAgent(proxyUrl);
-}
+const NPM_REGISTRY_URL = 'http://registry.npmjs.org'
 
 const REACT_NATIVE_PACKAGE_JSON_PATH = function() {
   return path.resolve(
@@ -27,63 +22,73 @@ const REACT_NATIVE_PACKAGE_JSON_PATH = function() {
     'node_modules',
     'react-native',
     'package.json'
-  );
-};
+  )
+}
+
+const npm = new Registry({registry: NPM_REGISTRY_URL})
 
 function getLatestVersion() {
-  return fetch('https://registry.npmjs.org/react-native-windows?version=latest', options)
-    .then(result => result && result.ok && result.json())
-    .then(result => result.version)
+  return new Promise(function (resolve, reject) {
+    npm.packages.release('react-native-windows', 'latest', (err, release) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(release.version)
+      }
+    })
+  })
 }
 
 function getMatchingVersion(version) {
   console.log(`Checking for react-native-windows version matching ${version}...`)
-  return fetch(`https://registry.npmjs.org/react-native-windows?version=${version}`, options)
-    .then(result => {
-      if (result && result.ok) {
-        return result.json().then(pkg => pkg.version);
+  return new Promise(function (resolve, reject) {
+    npm.packages.range('react-native-windows', version, (err, release) => {
+      if (err) {
+        return getLatestVersion()
+          .then(latestVersion => {
+            reject(new Error(`Could not find react-native-windows@${version}. ` +
+              `Latest version of react-native-windows is ${latestVersion}, try switching to ` +
+              `react-native@${semver.major(latestVersion)}.${semver.minor(latestVersion)}.*.`))
+            }).catch(error => reject(new Error(`Could not find react-native-windows@${version}.`)))
       } else {
-        return getLatestVersion().then(latestVersion => {
-          throw new Error(`Could not find react-native-windows@${version}. ` +
-            `Latest version of react-native-windows is ${latestVersion}, try switching to ` +
-            `react-native@${semver.major(latestVersion)}.${semver.minor(latestVersion)}.*.`);
-        });
+        resolve(release.version)
       }
-    });
+    })
+  })
 }
 
 const getInstallPackage = function (version) {
-  let packageToInstall = 'react-native-windows';
+  let packageToInstall = 'react-native-windows'
 
-  const validVersion = semver.valid(version);
-  const validRange = semver.validRange(version);
+  const validVersion = semver.valid(version)
+  const validRange = semver.validRange(version)
   if ((validVersion && !semver.gtr(validVersion, '0.26.*')) ||
       (!validVersion && validRange && semver.gtr('0.27.0', validRange))) {
     console.error(
       'Please upgrade react-native to ^0.27 or specify a --windowsVersion that is >=0.27.0'
-    );
-    process.exit(1);
+    )
+    process.exit(1)
   }
 
   if (validVersion || validRange) {
     return getMatchingVersion(version)
-      .then(resultVersion => packageToInstall + '@' + resultVersion);
+      .then(resultVersion => packageToInstall + '@' + resultVersion)
   } else {
-    return Promise.resolve(version);
+    return Promise.resolve(version)
   }
 }
 
 const getReactNativeVersion = function () {
-  console.log('Reading react-native version from node_modules...');
+  console.log('Reading react-native version from node_modules...')
   if (fs.existsSync(REACT_NATIVE_PACKAGE_JSON_PATH())) {
-    const version = JSON.parse(fs.readFileSync(REACT_NATIVE_PACKAGE_JSON_PATH(), 'utf-8')).version;
-    return `${semver.major(version)}.${semver.minor(version)}.*`;
+    const version = JSON.parse(fs.readFileSync(REACT_NATIVE_PACKAGE_JSON_PATH(), 'utf-8')).version
+    return `${semver.major(version)}.${semver.minor(version)}.*`
   }
 }
 
 const getReactNativeAppName = function () {
-  console.log('Reading application name from package.json...');
-  return JSON.parse(fs.readFileSync('package.json', 'utf8')).name;
+  console.log('Reading application name from package.json...')
+  return JSON.parse(fs.readFileSync('package.json', 'utf8')).name
 }
 
 module.exports = {


### PR DESCRIPTION
Instead of using an ad hoc HTTP approach, we're now consuming the `npm-registry` package, which should hopefully provide more consistent behavior over time.

Fixes #1005