### PR TITLE
fix(TouchHandler): touch point offset due to status bar

### DIFF
--- a/ReactWindows/ReactNative/Touch/TouchHandler.cs
+++ b/ReactWindows/ReactNative/Touch/TouchHandler.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
+using Windows.Graphics.Display;
 using Windows.UI.Input;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
@@ -303,6 +304,13 @@ namespace ReactNative.Touch
 
         private static Point AdjustPointForStatusBar(Point point)
         {
+            var currentOrientation = DisplayInformation.GetForCurrentView().CurrentOrientation;
+            if (currentOrientation == DisplayOrientations.Landscape ||
+                currentOrientation == DisplayOrientations.LandscapeFlipped)
+            {
+                return point;    
+            }
+
             if (ApiInformation.IsTypePresent("Windows.UI.ViewManagement.StatusBar"))
             {
                 var rect = StatusBar.GetForCurrentView().OccludedRect;

--- a/ReactWindows/ReactNative/Touch/TouchHandler.cs
+++ b/ReactWindows/ReactNative/Touch/TouchHandler.cs
@@ -305,13 +305,9 @@ namespace ReactNative.Touch
         private static Point AdjustPointForStatusBar(Point point)
         {
             var currentOrientation = DisplayInformation.GetForCurrentView().CurrentOrientation;
-            if (currentOrientation == DisplayOrientations.Landscape ||
-                currentOrientation == DisplayOrientations.LandscapeFlipped)
-            {
-                return point;    
-            }
-
-            if (ApiInformation.IsTypePresent("Windows.UI.ViewManagement.StatusBar"))
+            if (currentOrientation != DisplayOrientations.Landscape &&
+                currentOrientation != DisplayOrientations.LandscapeFlipped &&
+                ApiInformation.IsTypePresent("Windows.UI.ViewManagement.StatusBar"))
             {
                 var rect = StatusBar.GetForCurrentView().OccludedRect;
                 point.Y += rect.Height;


### PR DESCRIPTION
A previous change to adjust the touch point for a visible status bar does not seem to be necessary when the device is in landscape orientation.

Fixes #945