### PR TITLE
Support allowFontScaling

### DIFF
--- a/ReactWindows/ReactNative.Shared/UIManager/ViewProps.cs
+++ b/ReactWindows/ReactNative.Shared/UIManager/ViewProps.cs
@@ -72,6 +72,7 @@ namespace ReactNative.UIManager
         public const string TextAlign = "textAlign";
         public const string TextAlignVertical = "textAlignVertical";
         public const string TextDecorationLine = "textDecorationLine";
+        public const string AllowFontScaling = "allowFontScaling";
 
         public const string BorderWidth = "borderWidth";
         public const string BorderLeftWidth = "borderLeftWidth";

--- a/ReactWindows/ReactNative/Views/Text/ReactTextShadowNode.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactTextShadowNode.cs
@@ -24,6 +24,8 @@ namespace ReactNative.Views.Text
         private double? _fontSize;
         private double _lineHeight;
 
+        private bool _allowFontScaling;
+
         private FontStyle? _fontStyle;
         private FontWeight? _fontWeight;
         private TextAlignment _textAlignment = TextAlignment.DetectFromContent;
@@ -162,6 +164,20 @@ namespace ReactNative.Views.Text
         }
 
         /// <summary>
+        /// Set fontScaling
+        /// </summary>
+        /// <param name="allowFontScaling">Max number of lines.</param>
+        [ReactProp(ViewProps.AllowFontScaling)]
+        public virtual void SetAllowFontScaling(bool allowFontScaling)
+        {
+            if (_allowFontScaling != allowFontScaling)
+            {
+                _allowFontScaling = allowFontScaling;
+                MarkUpdated();
+            }
+        }
+
+        /// <summary>
         /// Called after a layout step at the end of a UI batch from
         /// <see cref="UIManagerModule"/>. May be used to enqueue additional UI
         /// operations for the native view. Will only be called on nodes marked
@@ -243,6 +259,7 @@ namespace ReactNative.Views.Text
             textBlock.FontSize = _fontSize ?? 15;
             textBlock.FontStyle = _fontStyle ?? FontStyle.Normal;
             textBlock.FontWeight = _fontWeight ?? FontWeights.Normal;
+            textBlock.IsTextScaleFactorEnabled = _allowFontScaling;
 
             if (!measureOnly)
             {


### PR DESCRIPTION
iOS and apparently Android in RN support allowFontScaling that can be used to prevent users from changing font scaling in accessibility settings. Ran into this through a customer using ARM device and made a quick fix that seems to work

If something is missing please comment this was made quite quickly.