### PR TITLE
fix(Yoga): Pointing at patched NuGet package to fix AVE

### DIFF
--- a/ReactWindows/Playground.Net46/Playground.Net46.csproj
+++ b/ReactWindows/Playground.Net46/Playground.Net46.csproj
@@ -125,7 +125,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Facebook.Yoga, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Facebook.Yoga.1.1.0.23-pre\lib\net45\Facebook.Yoga.dll</HintPath>
+      <HintPath>..\packages\Facebook.Yoga.1.2.0.2-patch\lib\netstandard\Facebook.Yoga.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -179,12 +179,12 @@
     <PostBuildEvent>
     </PostBuildEvent>
   </PropertyGroup>
-  <Import Project="..\packages\Facebook.Yoga.1.1.0.23-pre\build\net45\Facebook.Yoga.targets" Condition="Exists('..\packages\Facebook.Yoga.1.1.0.23-pre\build\net45\Facebook.Yoga.targets')" />
+  <Import Project="..\packages\Facebook.Yoga.1.2.0.2-patch\build\netstandard\Facebook.Yoga.targets" Condition="Exists('..\packages\Facebook.Yoga.1.2.0.2-patch\build\netstandard\Facebook.Yoga.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Facebook.Yoga.1.1.0.23-pre\build\net45\Facebook.Yoga.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Facebook.Yoga.1.1.0.23-pre\build\net45\Facebook.Yoga.targets'))" />
+    <Error Condition="!Exists('..\packages\Facebook.Yoga.1.2.0.2-patch\build\netstandard\Facebook.Yoga.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Facebook.Yoga.1.2.0.2-patch\build\netstandard\Facebook.Yoga.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/ReactWindows/Playground.Net46/packages.config
+++ b/ReactWindows/Playground.Net46/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Facebook.Yoga" version="1.1.0.23-pre" targetFramework="net46" />
+  <package id="Facebook.Yoga" version="1.2.0.2-patch" targetFramework="net46" />
 </packages>

--- a/ReactWindows/Playground/project.json
+++ b/ReactWindows/Playground/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Facebook.Yoga": "1.1.0.23-pre",
+    "Facebook.Yoga": "1.2.0.2-patch",
     "Microsoft.ApplicationInsights": "2.2.0",
     "Microsoft.ApplicationInsights.PersistenceChannel": "1.2.3",
     "Microsoft.ApplicationInsights.WindowsApps": "1.1.1",

--- a/ReactWindows/ReactNative.Net46.Tests/ReactNative.Net46.Tests.csproj
+++ b/ReactWindows/ReactNative.Net46.Tests/ReactNative.Net46.Tests.csproj
@@ -79,7 +79,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Facebook.Yoga, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Facebook.Yoga.1.1.0.23-pre\lib\net45\Facebook.Yoga.dll</HintPath>
+      <HintPath>..\packages\Facebook.Yoga.1.2.0.2-patch\lib\netstandard\Facebook.Yoga.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
@@ -148,11 +148,11 @@
   </ItemGroup>
   <Import Project="..\ReactNative.Shared.Tests\ReactNative.Shared.Tests.projitems" Label="Shared" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Facebook.Yoga.1.1.0.23-pre\build\net45\Facebook.Yoga.targets" Condition="Exists('..\packages\Facebook.Yoga.1.1.0.23-pre\build\net45\Facebook.Yoga.targets')" />
+  <Import Project="..\packages\Facebook.Yoga.1.2.0.2-patch\build\netstandard\Facebook.Yoga.targets" Condition="Exists('..\packages\Facebook.Yoga.1.2.0.2-patch\build\netstandard\Facebook.Yoga.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Facebook.Yoga.1.1.0.23-pre\build\net45\Facebook.Yoga.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Facebook.Yoga.1.1.0.23-pre\build\net45\Facebook.Yoga.targets'))" />
+    <Error Condition="!Exists('..\packages\Facebook.Yoga.1.2.0.2-patch\build\netstandard\Facebook.Yoga.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Facebook.Yoga.1.2.0.2-patch\build\netstandard\Facebook.Yoga.targets'))" />
   </Target>
 </Project>

--- a/ReactWindows/ReactNative.Net46.Tests/packages.config
+++ b/ReactWindows/ReactNative.Net46.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Facebook.Yoga" version="1.1.0.23-pre" targetFramework="net46" />
+  <package id="Facebook.Yoga" version="1.2.0.2-patch" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="NMock3" version="3.5.44" targetFramework="net46" />
   <package id="NUnit" version="3.5.0" targetFramework="net46" />

--- a/ReactWindows/ReactNative.Net46/ReactNative.Net46.csproj
+++ b/ReactWindows/ReactNative.Net46/ReactNative.Net46.csproj
@@ -61,7 +61,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Facebook.Yoga, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\Facebook.Yoga.1.1.0.23-pre\lib\net45\Facebook.Yoga.dll</HintPath>
+      <HintPath>..\packages\Facebook.Yoga.1.2.0.2-patch\lib\netstandard\Facebook.Yoga.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -215,10 +215,10 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\packages\Facebook.Yoga.1.1.0.23-pre\build\net45\Facebook.Yoga.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Facebook.Yoga.1.1.0.18-pre\build\net45\Facebook.Yoga.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.ChakraCore.1.4.1\build\netstandard1.0\Microsoft.ChakraCore.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.ChakraCore.1.4.1\build\netstandard1.0\Microsoft.ChakraCore.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\Facebook.Yoga.1.2.0.2-patch\build\netstandard\Facebook.Yoga.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Facebook.Yoga.1.2.0.2-patch\build\netstandard\Facebook.Yoga.targets'))" />
   </Target>
-  <Import Project="$(SolutionDir)\packages\Facebook.Yoga.1.1.0.23-pre\build\net45\Facebook.Yoga.targets" Condition="Exists('$(SolutionDir)\packages\Facebook.Yoga.1.1.0.23-pre\build\net45\Facebook.Yoga.targets')" />
+  <Import Project="$(SolutionDir)\packages\Facebook.Yoga.1.2.0.2-patch\build\netstandard\Facebook.Yoga.targets" Condition="Exists('$(SolutionDir)\packages\Facebook.Yoga.1.2.0.2-patch\build\netstandard\Facebook.Yoga.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/ReactWindows/ReactNative.Net46/packages.config
+++ b/ReactWindows/ReactNative.Net46/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Facebook.Yoga" version="1.1.0.23-pre" targetFramework="net46" />
+  <package id="Facebook.Yoga" version="1.2.0.2-patch" targetFramework="net46" />
   <package id="Microsoft.ChakraCore" version="1.4.1" targetFramework="net46" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="PCLStorage" version="1.0.2" targetFramework="net46" />

--- a/ReactWindows/ReactNative.Tests/project.json
+++ b/ReactWindows/ReactNative.Tests/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Facebook.Yoga": "1.1.0.23-pre",
+    "Facebook.Yoga": "1.2.0.2-patch",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
     "NUnit": "3.5.0",
     "NUnit3TestAdapter": "3.5.0"

--- a/ReactWindows/ReactNative/project.json
+++ b/ReactWindows/ReactNative/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Facebook.Yoga": "1.1.0.23-pre",
+    "Facebook.Yoga": "1.2.0.2-patch",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
     "Microsoft.Toolkit.Uwp.UI": "1.3.1",
     "Newtonsoft.Json": "9.0.1",


### PR DESCRIPTION
Facebook.Yoga was throwing an AccessViolationException on ARM devices due to a marshaling error. We added a patch to work around this limitation.

Fixes #1027