### PR TITLE
fix(init): remove Facebook.Yoga package reference

### DIFF
--- a/local-cli/generator-windows/templates/src/project.json
+++ b/local-cli/generator-windows/templates/src/project.json
@@ -1,6 +1,5 @@
 ﻿{
   "dependencies": {
-    "Facebook.Yoga": "1.0.2-pre",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2"
   },
   "frameworks": {


### PR DESCRIPTION
The Facebook.Yoga package reference is not needed, and creates another place that needs to be upgraded each time we upgrade the NuGet package.