### PR TITLE
Support textDecorationLine on <Text> components (#709)

### DIFF
--- a/ReactWindows/ReactNative.Net46/ReactNative.Net46.csproj
+++ b/ReactWindows/ReactNative.Net46/ReactNative.Net46.csproj
@@ -107,7 +107,6 @@
       <HintPath>$(SolutionDir)\packages\System.Reactive.Windows.Threading.3.1.1\lib\net45\System.Reactive.Windows.Threading.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />

--- a/ReactWindows/ReactNative.Net46/ReactNative.Net46.csproj
+++ b/ReactWindows/ReactNative.Net46/ReactNative.Net46.csproj
@@ -107,6 +107,7 @@
       <HintPath>$(SolutionDir)\packages\System.Reactive.Windows.Threading.3.1.1\lib\net45\System.Reactive.Windows.Threading.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />

--- a/ReactWindows/ReactNative.Net46/Views/Text/ReactTextShadowNode.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Text/ReactTextShadowNode.cs
@@ -4,6 +4,7 @@ using ReactNative.Reflection;
 using ReactNative.UIManager;
 using ReactNative.UIManager.Annotations;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -26,6 +27,8 @@ namespace ReactNative.Views.Text
         private FontWeight? _fontWeight;
         private TextAlignment _textAlignment = TextAlignment.Left;
 
+        private TextDecorationLine _textDecorationLine = TextDecorationLine.None;
+
         private string _fontFamily;
 
         /// <summary>
@@ -35,6 +38,37 @@ namespace ReactNative.Views.Text
         {
             MeasureFunction = (node, width, widthMode, height, heightMode) =>
                 MeasureText(this, node, width, widthMode, height, heightMode);
+        }
+
+        /// <summary>
+        /// Sets the TextDecorationLine for the node.
+        /// </summary>
+        /// <param name="textDecorationLineValue">The TextDecorationLine value.</param>
+        [ReactProp(ViewProps.TextDecorationLine)]
+        public void SetTextDecorationLine(string textDecorationLineValue)
+        {
+            var textDecorationLine = EnumHelpers.ParseNullable<TextDecorationLine>(textDecorationLineValue) ?? TextDecorationLine.None;
+            if (_textDecorationLine != textDecorationLine)
+            {
+                _textDecorationLine = textDecorationLine;
+                MarkUpdated();
+            }
+        }
+
+        private IEnumerable<TextDecoration> GetTextDecorationCollection()
+        {
+            switch (_textDecorationLine)
+            {
+                case TextDecorationLine.Underline:
+                    return TextDecorations.Underline;
+                case TextDecorationLine.LineThrough:
+                    return TextDecorations.Strikethrough;
+                case TextDecorationLine.UnderlineLineThrough:
+                    return TextDecorations.Underline.Concat(TextDecorations.Strikethrough);
+                case TextDecorationLine.None:
+                default:
+                    return Enumerable.Empty<TextDecoration>();
+            }
         }
 
         /// <summary>
@@ -238,6 +272,7 @@ namespace ReactNative.Views.Text
             textBlock.FontSize = _fontSize ?? 15;
             textBlock.FontStyle = _fontStyle ?? new FontStyle();
             textBlock.FontWeight = _fontWeight ?? FontWeights.Normal;
+            textBlock.TextDecorations = new TextDecorationCollection(GetTextDecorationCollection());
 
             if (_fontFamily != null)
             {

--- a/ReactWindows/ReactNative.Net46/Views/Text/ReactTextShadowNode.cs
+++ b/ReactWindows/ReactNative.Net46/Views/Text/ReactTextShadowNode.cs
@@ -55,19 +55,22 @@ namespace ReactNative.Views.Text
             }
         }
 
-        private IEnumerable<TextDecoration> GetTextDecorationCollection()
+        private IEnumerable<TextDecoration> TextDecorationCollection
         {
-            switch (_textDecorationLine)
+            get
             {
-                case TextDecorationLine.Underline:
-                    return TextDecorations.Underline;
-                case TextDecorationLine.LineThrough:
-                    return TextDecorations.Strikethrough;
-                case TextDecorationLine.UnderlineLineThrough:
-                    return TextDecorations.Underline.Concat(TextDecorations.Strikethrough);
-                case TextDecorationLine.None:
-                default:
-                    return Enumerable.Empty<TextDecoration>();
+                switch (_textDecorationLine)
+                {
+                    case TextDecorationLine.Underline:
+                        return TextDecorations.Underline;
+                    case TextDecorationLine.LineThrough:
+                        return TextDecorations.Strikethrough;
+                    case TextDecorationLine.UnderlineLineThrough:
+                        return TextDecorations.Underline.Concat(TextDecorations.Strikethrough);
+                    case TextDecorationLine.None:
+                    default:
+                        return Enumerable.Empty<TextDecoration>();
+                }
             }
         }
 
@@ -272,7 +275,7 @@ namespace ReactNative.Views.Text
             textBlock.FontSize = _fontSize ?? 15;
             textBlock.FontStyle = _fontStyle ?? new FontStyle();
             textBlock.FontWeight = _fontWeight ?? FontWeights.Normal;
-            textBlock.TextDecorations = new TextDecorationCollection(GetTextDecorationCollection());
+            textBlock.TextDecorations = new TextDecorationCollection(TextDecorationCollection);
 
             if (_fontFamily != null)
             {

--- a/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
+++ b/ReactWindows/ReactNative.Shared/ReactNative.Shared.projitems
@@ -230,6 +230,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Views\TextInput\ReactTextInputSelectionEvent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Views\TextInput\ReactTextInputShadowNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Views\TextInput\ReactTextInputSubmitEditingEvent.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Views\Text\TextDecorationLine.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Views\ViewManagersPropertyCache.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Views\View\ReactViewManager.cs" />
   </ItemGroup>

--- a/ReactWindows/ReactNative.Shared/Reflection/EnumHelpers.cs
+++ b/ReactWindows/ReactNative.Shared/Reflection/EnumHelpers.cs
@@ -39,12 +39,12 @@ namespace ReactNative.Reflection
             return Parse<T>(value);
         }
 
-        private static Dictionary<string, object> EnumToDictionary(Type t)
+        private static Dictionary<string, object> EnumToDictionary(Type type)
         {
             var result = new Dictionary<string, object>();
 
-            var names = Enum.GetNames(t);
-            var values = Enum.GetValues(t);
+            var names = Enum.GetNames(type);
+            var values = Enum.GetValues(type);
 
             for (int i = 0; i < values.Length; ++i)
             {
@@ -53,7 +53,7 @@ namespace ReactNative.Reflection
 
                 result.Add(Normalize(name), value);
 
-                var enumMemberAttribute = t.GetField(name).GetCustomAttributes(typeof(EnumMemberAttribute), true).SingleOrDefault();
+                var enumMemberAttribute = type.GetField(name).GetCustomAttributes(typeof(EnumMemberAttribute), true).SingleOrDefault();
                 if (enumMemberAttribute != null)
                 {
                     result.Add(Normalize(((EnumMemberAttribute)enumMemberAttribute).Value), value);

--- a/ReactWindows/ReactNative.Shared/Reflection/EnumHelpers.cs
+++ b/ReactWindows/ReactNative.Shared/Reflection/EnumHelpers.cs
@@ -2,6 +2,8 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
 using static System.FormattableString;
 
 namespace ReactNative.Reflection
@@ -15,11 +17,7 @@ namespace ReactNative.Reflection
         {
             var lookup = s_enumCache.GetOrAdd(
                 typeof(T),
-                type => Enum.GetValues(type)
-                    .Cast<object>()
-                    .ToDictionary(
-                        e => Normalize(e.ToString()),
-                        e => e));
+                type => EnumToDictionary(type));
 
             var result = default(object);
             if (!lookup.TryGetValue(Normalize(value), out result))
@@ -39,6 +37,30 @@ namespace ReactNative.Reflection
                 return null;
 
             return Parse<T>(value);
+        }
+
+        private static Dictionary<string, object> EnumToDictionary(Type t)
+        {
+            Dictionary<string, object> result = new Dictionary<string, object>();
+
+            var names = Enum.GetNames(t);
+            var values = Enum.GetValues(t);
+
+            for (int i = 0; i < values.Length; ++i)
+            {
+                string name = names[i];
+                object value = values.GetValue(i);
+
+                result.Add(Normalize(name), value);
+
+                var enumMemberAttribute = t.GetField(name).GetCustomAttributes(typeof(EnumMemberAttribute), true).SingleOrDefault();
+                if (enumMemberAttribute != null)
+                {
+                    result.Add(Normalize(((EnumMemberAttribute)enumMemberAttribute).Value), value);
+                }
+            }
+
+            return result;
         }
 
         private static string Normalize(string value)

--- a/ReactWindows/ReactNative.Shared/Reflection/EnumHelpers.cs
+++ b/ReactWindows/ReactNative.Shared/Reflection/EnumHelpers.cs
@@ -41,7 +41,7 @@ namespace ReactNative.Reflection
 
         private static Dictionary<string, object> EnumToDictionary(Type t)
         {
-            Dictionary<string, object> result = new Dictionary<string, object>();
+            var result = new Dictionary<string, object>();
 
             var names = Enum.GetNames(t);
             var values = Enum.GetValues(t);

--- a/ReactWindows/ReactNative.Shared/Views/Text/TextDecorationLine.cs
+++ b/ReactWindows/ReactNative.Shared/Views/Text/TextDecorationLine.cs
@@ -1,0 +1,28 @@
+﻿using System.Runtime.Serialization;
+
+namespace ReactNative.Views.Text
+{
+    /// <summary>
+    /// TextDecorationLine values.
+    /// </summary>
+    public enum TextDecorationLine
+    {
+        /// <summary>
+        /// Text has no line decoration.
+        /// </summary>
+        None,
+        /// <summary>
+        /// Text is Underlined.
+        /// </summary>
+        Underline,
+        /// <summary>
+        /// Text is Stroke out.
+        /// </summary>
+        LineThrough,
+        /// <summary>
+        /// Text is both Underlined and Stroke out.
+        /// </summary>
+        [EnumMember(Value = "underline line-through")]
+        UnderlineLineThrough
+    }
+}

--- a/ReactWindows/ReactNative/Views/Text/ReactTextViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactTextViewManager.cs
@@ -80,7 +80,7 @@ namespace ReactNative.Views.Text
                         var paragraph = view.Blocks.OfType<Paragraph>().First();
                         paragraph.Inlines.Clear();
                         firstItemAsUnderline.Inlines.Clear();
-                        foreach (Inline i in inlines)
+                        foreach (var i in inlines)
                         {
                             paragraph.Inlines.Add(i);
                         }
@@ -96,8 +96,8 @@ namespace ReactNative.Views.Text
                         var paragraph = view.Blocks.OfType<Paragraph>().First();
                         paragraph.Inlines.Clear();
 
-                        Underline underline = new Underline();
-                        foreach (Inline i in inlines)
+                        var underline = new Underline();
+                        foreach (var i in inlines)
                         {
                             underline.Inlines.Add(i);
                         }

--- a/ReactWindows/ReactNative/Views/Text/ReactTextViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactTextViewManager.cs
@@ -80,9 +80,9 @@ namespace ReactNative.Views.Text
                         var paragraph = view.Blocks.OfType<Paragraph>().First();
                         paragraph.Inlines.Clear();
                         firstItemAsUnderline.Inlines.Clear();
-                        foreach (var i in inlines)
+                        foreach (var inline in inlines)
                         {
-                            paragraph.Inlines.Add(i);
+                            paragraph.Inlines.Add(inline);
                         }
                         break;
                     }
@@ -97,9 +97,9 @@ namespace ReactNative.Views.Text
                         paragraph.Inlines.Clear();
 
                         var underline = new Underline();
-                        foreach (var i in inlines)
+                        foreach (var inline in inlines)
                         {
-                            underline.Inlines.Add(i);
+                            underline.Inlines.Add(inline);
                         }
 
                         paragraph.Inlines.Add(underline);


### PR DESCRIPTION
WPF supports both Underline and Strike-through
UWP supports only Underline. The idea behind this approach was to add an Underline directly to a Paragraph of RichTextBlock, because we know that there is always one Paragraph and thus there should be at most one Underline.